### PR TITLE
Create swift package description for Nimbus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 
+/.build
 /dist
 
 # Created by https://www.gitignore.io/api/node,typings,visualstudiocode

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "Nimbus",
+    platforms: [
+        .macOS(.v10_14), .iOS(.v11)
+    ],
+    products: [
+        .library(
+            name: "Nimbus",
+            targets: ["Nimbus"]),
+    ],
+    dependencies: [
+    ],
+    targets: [
+        .target(
+            name: "Nimbus",
+            path: "platforms/apple/Sources/Nimbus"),
+        .testTarget(
+            name: "NimbusTests",
+            dependencies: ["Nimbus"],
+            path: "platforms/apple/Sources/NimbusTests"),
+    ],
+    swiftLanguageVersions: [.v4_2]
+)


### PR DESCRIPTION
This package description uses the beta version of Swift Package Manager from Xcode 11 beta. The goal is to be ready for consumption as a swift package as soon as Xcode 11 GM ships in the hopes that swiftpm quickly replaces carthage and cocoapods as the defacto iOS/macOS package manager.