### PR TITLE
Allow non-primitive types in callback parameter.

### DIFF
--- a/demo-www/src/nimbus/app/app.html
+++ b/demo-www/src/nimbus/app/app.html
@@ -2,4 +2,9 @@
   <p>Hi there.</p>
   <p>Last click: {lastClick}</p>
   <button onclick={showTime}>Show Time</button>
+  <br />
+  <p>Get user defined data type back via a callback.</p>
+  <button onclick={getUddt}>Get User Defined Data Type</button>
+  <p>String property on UDDT: {uddtString}</p>
+  <p>Integer property on UDDT: {uddtNumber}</p>
 </template>

--- a/demo-www/src/nimbus/app/app.js
+++ b/demo-www/src/nimbus/app/app.js
@@ -8,8 +8,9 @@
 import {LightningElement, track} from 'lwc';
 
 export default class App extends LightningElement {
-  @track
-  lastClick = "never";
+  @track lastClick = "never";
+  @track uddtString = "";
+  @track uddtNumber = "";
 
   constructor() {
     super();
@@ -18,4 +19,13 @@ export default class App extends LightningElement {
   showTime(e) {
     DemoBridge.currentTime().then(t => this.lastClick = t);
   }
+
+  getUddt(e) {
+    DemoBridge.getDataViaCallback((myUserDefinedDataType) => {
+      this.uddtString = myUserDefinedDataType.stringParam;
+      this.uddtNumber = myUserDefinedDataType.intParam;
+    })
+  }
+
+
 }

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/SimpleBridgeExtension.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/SimpleBridgeExtension.kt
@@ -36,6 +36,25 @@ class SimpleBridgeExtension : NimbusExtension {
         }
     }
 
+    data class MyUserDefinedDataType(val intParam: Int = 5, val stringParam: String = "hello my user defined type"): JSONSerializable {
+        override fun stringify(): String {
+            val jsonObject = JSONObject()
+            jsonObject.put("intParam", intParam)
+            jsonObject.put("stringParam", stringParam)
+            return jsonObject.toString()
+        }
+
+        companion object {
+            @JvmStatic
+            fun fromJSON(jsonString: String): MyUserDefinedDataType {
+                val json = JSONObject(jsonString)
+                val intParam = json.optInt("intParam")
+                val stringParam = json.optString("stringParam", "stringParam")
+                return MyUserDefinedDataType(intParam, stringParam)
+            }
+        }
+    }
+
     @ExtensionMethod
     fun currentTime(): String {
         return Date().toString()
@@ -76,5 +95,10 @@ class SimpleBridgeExtension : NimbusExtension {
     @ExtensionMethod
     fun serializable(): Foo {
         return Foo("Astro", "mascot")
+    }
+
+    @ExtensionMethod
+    fun getDataViaCallback(arg:(MyUserDefinedDataType) -> Unit) {
+        arg(MyUserDefinedDataType())
     }
 }

--- a/platforms/android/nimbus-compiler/src/main/java/com/salesforce/nimbus/NimbusProcessor.kt
+++ b/platforms/android/nimbus-compiler/src/main/java/com/salesforce/nimbus/NimbusProcessor.kt
@@ -158,8 +158,22 @@ class NimbusProcessor : AbstractProcessor() {
                                         if (typeMirror.kind == TypeKind.WILDCARD) {
                                             val wild = typeMirror as WildcardType
                                             invoke.addParameter(TypeName.get(wild.superBound), "arg$index")
+
+                                            val supertypes = processingEnv.typeUtils.directSupertypes(wild.superBound)
+                                            var found = false
+                                            for (supertype in supertypes) {
+                                                if (supertype.toString().equals("com.salesforce.nimbus.JSONSerializable")) {
+                                                    found = true
+                                                }
+                                            }
+                                            if (found) {
+                                                argBlock.add("arg$index, \n")
+                                            } else {
+                                                argBlock.add("arg$index != null ? new \$T(arg$index) : null,\n", ClassName.get("com.salesforce.nimbus", "PrimitiveJSONSerializable"))
+                                            }
+                                        } else {
+                                            argBlock.add("arg$index != null ? new \$T(arg$index) : null,\n", ClassName.get("com.salesforce.nimbus", "PrimitiveJSONSerializable"))
                                         }
-                                        argBlock.add("arg$index != null ? new \$T(arg$index) : null,\n", ClassName.get("com.salesforce.nimbus", "PrimitiveJSONSerializable"))
                                     }
 
                                     argBlock.unindent().add("};\n")

--- a/platforms/android/nimbus/build.gradle
+++ b/platforms/android/nimbus/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     }
+    kaptAndroidTest project(":nimbus-compiler")
 }
 
 /*

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/MochaTests.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/MochaTests.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit
 @RunWith(AndroidJUnit4::class)
 class MochaTests {
 
-    data class MochaMessage(val stringField: String = "This is a string", val intField: Int = 42) : JSONSerializable {
+    data class MochaMessage(var stringField: String = "This is a string", var intField: Int = 42) : JSONSerializable {
         override fun stringify(): String {
             val jsonObject = JSONObject()
             jsonObject.put("stringField", stringField)
@@ -73,9 +73,12 @@ class MochaTests {
         val webView = activityRule.activity.webView
         val testBridge = MochaTestBridge(webView)
 
+        val bridge = NimbusBridge("file:///android_asset/test-www/index.html")
+
         runOnUiThread {
             webView.addJavascriptInterface(testBridge, "mochaTestBridge")
-            webView.loadUrl("file:///android_asset/test-www/index.html")
+            bridge.add(CallbackTestExtensionBinder(CallbackTestExtension()))
+            bridge.attach(webView)
         }
 
         testBridge.readyLatch.await(5, TimeUnit.SECONDS)

--- a/platforms/android/nimbus/src/main/java/com/salesforce/nimbus/WebViewExtensions.kt
+++ b/platforms/android/nimbus/src/main/java/com/salesforce/nimbus/WebViewExtensions.kt
@@ -8,6 +8,7 @@
 package com.salesforce.nimbus
 
 import android.webkit.WebView
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -24,23 +25,21 @@ import org.json.JSONObject
  *                          have to pass a closure if you are not interested in getting the callback.
  */
 fun WebView.callJavascript(name: String, args: Array<JSONSerializable?> = emptyArray(), completionHandler: ((result: Any?) -> Unit)? = null) {
-    val jsonObject = JSONObject()
+    val jsonArray = JSONArray()
     args.forEachIndexed { index, jsonSerializable ->
         val asPrimitive = jsonSerializable as? PrimitiveJSONSerializable
         if (asPrimitive != null) {
-            jsonObject.put(index.toString(), asPrimitive.value)
+            jsonArray.put(asPrimitive.value)
         } else {
-            jsonObject.put(index.toString(),
-                    if (jsonSerializable == null) JSONObject.NULL
+            jsonArray.put(if (jsonSerializable == null) JSONObject.NULL
                     else JSONObject(jsonSerializable.stringify()))
         }
     }
 
-    val jsonString = jsonObject.toString()
+    val jsonString = jsonArray.toString()
     val scriptTemplate = """
         try {
-            var jsonData = $jsonString;
-            var jsonArr = Object.values(jsonData);
+            var jsonArr = $jsonString;
             if (jsonArr && jsonArr.length > 0) {
                 $name(...jsonArr);
             } else {

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -166,9 +166,9 @@
 		2970E44F224F0A06008DC004 /* NimbusDesktopUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NimbusDesktopUITests.swift; sourceTree = "<group>"; };
 		2970E451224F0A06008DC004 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2970E498224F0D46008DC004 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = System/Library/Frameworks/WebKit.framework; sourceTree = SDKROOT; };
-		29F8D60E223AF857005C5AC1 /* DeviceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceExtension.swift; sourceTree = "<group>"; };
 		298503D8228DEAAC00C1071E /* Binder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binder.swift; sourceTree = "<group>"; };
 		298503DA228DED3500C1071E /* BinderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinderTests.swift; sourceTree = "<group>"; };
+		29F8D60E223AF857005C5AC1 /* DeviceExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceExtension.swift; sourceTree = "<group>"; };
 		F0639DA54032B895278BC4F0 /* libPods-Nimbus.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Nimbus.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4C5ADAA535D8E3DA7092137 /* libPods-NimbusApp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NimbusApp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F758AEB65FD9A33F4F5EC397 /* Pods-NimbusApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NimbusApp.release.xcconfig"; path = "Target Support Files/Pods-NimbusApp/Pods-NimbusApp.release.xcconfig"; sourceTree = "<group>"; };

--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -58,7 +58,7 @@ extension Binder {
         let boundFunction = function(target)
         let wrappedFunction = { (callable: Callable) -> Void in
             try boundFunction { cb0 in
-                _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -68,11 +68,11 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<CB0, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (callable: Callable) -> Void in
             try boundFunction { cb0, cb1 in
-                _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0), EncodableValue.value(cb1)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -104,7 +104,7 @@ extension Binder {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0 in
-                _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -114,11 +114,11 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CB0, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0, cb1 in
-                _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0), EncodableValue.value(cb1)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -150,7 +150,7 @@ extension Binder {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0 in
-                _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -160,12 +160,11 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CB0, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void,
-                                                  as name: String) {
+    public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cb1 in
-                _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0), EncodableValue.value(cb1)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -198,7 +197,7 @@ extension Binder {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0 in
-                _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -208,12 +207,11 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void,
-                                                      as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0, cb1 in
-                _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0), EncodableValue.value(cb1)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -246,7 +244,7 @@ extension Binder {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0 in
-                _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -256,12 +254,11 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CB1) -> Void) throws -> Void,
-                                                          as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cb1 in
-                _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+                _ = try! callable.call(args: [EncodableValue.value(cb0), EncodableValue.value(cb1)]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)

--- a/platforms/apple/Sources/Nimbus/Callback.swift
+++ b/platforms/apple/Sources/Nimbus/Callback.swift
@@ -30,9 +30,9 @@ class Callback: Callable {
 
     func call(args: [Any]) throws -> Any {
         var jsonString: String = "[]"
-        if let bbb = args as? [EncodableValue] {
+        if let encodables = args as? [EncodableValue] {
             let jsonEncoder = JSONEncoder()
-            let jsonData = try? jsonEncoder.encode(bbb)
+            let jsonData = try? jsonEncoder.encode(encodables)
             jsonString = String(data: jsonData!, encoding: .utf8)!
         }
 

--- a/platforms/apple/Sources/Nimbus/Callback.swift
+++ b/platforms/apple/Sources/Nimbus/Callback.swift
@@ -29,11 +29,21 @@ class Callback: Callable {
     }
 
     func call(args: [Any]) throws -> Any {
-        let jsonData = try JSONSerialization.data(withJSONObject: args, options: [])
-        let jsonString = String(data: jsonData, encoding: .utf8)
+        var jsonString: String = "[]"
+        if let bbb = args as? [EncodableValue] {
+            let jsonEncoder = JSONEncoder()
+            let jsonData = try? jsonEncoder.encode(bbb)
+            jsonString = String(data: jsonData!, encoding: .utf8)!
+        }
+
         DispatchQueue.main.async {
             self.webView?.evaluateJavaScript("""
-            nimbus.callCallback('\(self.callbackId)', \(jsonString!));
+                var args = [];
+                var jsonArgs = \(jsonString);
+                jsonArgs.forEach(arg => {
+                    args.push(arg.v);
+                });
+                nimbus.callCallback('\(self.callbackId)', args);
             """)
         }
         return ()

--- a/platforms/apple/Sources/NimbusMobileApp/DemoBridge.swift
+++ b/platforms/apple/Sources/NimbusMobileApp/DemoBridge.swift
@@ -9,9 +9,18 @@ import Foundation
 import Nimbus
 import WebKit
 
+class MyUserDefinedDataType: Encodable {
+    var intParam = 5
+    var stringParam = "hello my user defined type"
+}
+
 class DemoBridge {
     func currentTime() -> String {
         return Date().description
+    }
+
+    func getDataViaCallback(completion:@escaping (MyUserDefinedDataType) -> Swift.Void) {
+        completion(MyUserDefinedDataType())
     }
 }
 
@@ -19,5 +28,6 @@ extension DemoBridge: NimbusExtension {
     func bindToWebView(webView: WKWebView) {
         let connection = webView.addConnection(to: self, as: "DemoBridge")
         connection.bind(DemoBridge.currentTime, as: "currentTime")
+        connection.bind(DemoBridge.getDataViaCallback, as: "getDataViaCallback")
     }
 }

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -36,8 +36,9 @@ class MochaTests: XCTestCase, WKNavigationDelegate {
                 webView.broadcastMessage(name: name)
             }
         }
-    }
 
+    }
+    
     var webView: WKWebView!
 
     var loadingExpectation: XCTestExpectation?
@@ -70,6 +71,8 @@ class MochaTests: XCTestCase, WKNavigationDelegate {
         connection.bind(MochaTestBridge.testsCompleted, as: "testsCompleted")
         connection.bind(MochaTestBridge.ready, as: "ready")
         connection.bind(MochaTestBridge.sendMessage, as: "sendMessage")
+        let callbackTestExtension = CallbackTestExtension()
+        callbackTestExtension.bindToWebView(webView: webView)
 
         loadWebViewAndWait()
 
@@ -78,5 +81,26 @@ class MochaTests: XCTestCase, WKNavigationDelegate {
 
         wait(for: [testBridge.expectation], timeout: 5)
         XCTAssertEqual(testBridge.failures, 0)
+    }
+}
+
+public class CallbackTestExtension {
+    func callbackWithSingleParam(completion: @escaping (MochaTests.MochaMessage) -> Swift.Void) {
+        let mochaMessage = MochaTests.MochaMessage()
+        completion(mochaMessage)
+    }
+    func callbackWithTwoParams(completion: @escaping (MochaTests.MochaMessage, MochaTests.MochaMessage) -> Swift.Void) {
+        var mochaMessage = MochaTests.MochaMessage()
+        mochaMessage.intField = 6
+        mochaMessage.stringField = "int param is 6"
+        completion(MochaTests.MochaMessage(), mochaMessage)
+    }
+}
+
+extension CallbackTestExtension: NimbusExtension {
+    public func bindToWebView(webView: WKWebView) {
+        let connection = webView.addConnection(to: self, as: "callbackTestExtension")
+        connection.bind(CallbackTestExtension.callbackWithSingleParam, as: "callbackWithSingleParam")
+        connection.bind(CallbackTestExtension.callbackWithTwoParams, as: "callbackWithTwoParams")
     }
 }

--- a/test-www/test/callback-encodable-tests.ts
+++ b/test-www/test/callback-encodable-tests.ts
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2019, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+import 'mocha';
+import {expect} from 'chai';
+
+describe('Callbacks with', () => {
+  it('single user defined data type is called', (done) => {
+    callbackTestExtension.callbackWithSingleParam((mm1: MochaMessage) => {
+       expect(mm1).to.deep.equal(
+         {intField: 42, stringField: 'This is a string'});
+      done();
+    });
+  });
+
+  it('two user defined data type is called', (done) => {
+    callbackTestExtension.callbackWithTwoParams((mm1: MochaMessage, mm2: MochaMessage) => {
+       expect(mm1).to.deep.equal(
+         {intField: 42, stringField: 'This is a string'});
+       expect(mm2).to.deep.equal(
+         {intField: 6, stringField: 'int param is 6'});
+      done();
+    });
+  });
+});

--- a/test-www/test/globals.d.ts
+++ b/test-www/test/globals.d.ts
@@ -5,9 +5,20 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
+interface MochaMessage {
+  intField: number;
+  stringField: string;
+}
+
 interface MochaTestBridge {
   ready(): void;
   sendMessage(name: string, includeParam: boolean): void;
 }
 
+interface CallbackTestExtension {
+  callbackWithSingleParam(completion: (mm1: MochaMessage) => void): void;
+  callbackWithTwoParams(completion: (mm1: MochaMessage, mm2: MochaMessage) => void): void;
+}
+
 declare var mochaTestBridge: MochaTestBridge;
+declare var callbackTestExtension: CallbackTestExtension;

--- a/test-www/test/index.ts
+++ b/test-www/test/index.ts
@@ -7,6 +7,7 @@
 
 import './nimbus-core-tests';
 import './broadcast-tests';
+import './callback-encodable-tests';
 import nimbus from 'nimbus';
 
 window.onload = () => {


### PR DESCRIPTION
These changes were made to support this feature:
* iOS callback parameters are wrapped as `EncodableValue`.
* Kotlin annotation processor was fixed to handle encoding of JSONObject/Array.
* Sample usage added to both demo app for iOS and Android.
* Added mocha tests to see in a round-trips that callback pass expected parameters.

Fixes https://github.com/salesforce/nimbus/issues/51
