### PR TITLE
include src and dist in NPM and ignore everything else

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
     "main": "dist/index.js",
     "module": "dist/index.js",
     "types": "dist/index.d.ts",
+    "files": [
+        "/src",
+        "/dist"
+    ],
     "scripts": {
         "build": "npm run compile && npm run bundle",
         "bundle": "rollup dist/index.js --file dist/nimbus.js --name nimbus --format iife",


### PR DESCRIPTION
Right now if I `npm install` nimbus (via github url today, but eventually via npm registry) I get all the native platforms and test folders and all that jazz... if I'm installing nimbus via NPM all I want is the dist and src (to see actual source TS files for debugging)... so this change explicitly sets the files to include for NPM packaging.