### PR TITLE
Add support iOS Foundation type.  Updated Android tests.

### DIFF
--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -19,6 +19,14 @@ interface CallbackTestExtension {
   callbackWithSinglePrimitiveParam(completion: (param0: number) => void): void;
   callbackWithTwoPrimitiveParams(completion: (param0: number, param1: number) => void): void;
   callbackWithPrimitiveAndUddtParams(completion: (param0: number, param1: MochaMessage) => void): void;
+  callbackWithPrimitiveAndArrayParams(completion: (param0: number, param1: Array<String>) => void): void;
+  callbackWithPrimitiveAndDictionaryParams(completion: (param0: number, param1: Object) => void): void;
+  callbackWithArrayAndUddtParams(completion: (param0: Array<String>, param1: MochaMessage) => void): void;
+  callbackWithArrayAndArrayParams(completion: (param0: Array<String>, param1: Array<String>) => void): void;
+  callbackWithArrayAndDictionaryParams(completion: (param0: Array<String>, param1: Object) => void): void;
+  callbackWithDictionaryAndUddtParams(completion: (param0: Object, param1: MochaMessage) => void): void;
+  callbackWithDictionaryAndArrayParams(completion: (param0: Object, param1: Array<String>) => void): void;
+  callbackWithDictionaryAndDictionaryParams(completion: (param0: Object, param1: Object) => void): void;
 }
 
 declare var callbackTestExtension: CallbackTestExtension;
@@ -28,7 +36,7 @@ describe('Callbacks with', () => {
     callbackTestExtension.callbackWithSingleParam((param0: MochaMessage) => {
        expect(param0).to.deep.equal(
          {intField: 42, stringField: 'This is a string'});
-      done();
+       done();
     });
   });
 
@@ -38,7 +46,7 @@ describe('Callbacks with', () => {
          {intField: 42, stringField: 'This is a string'});
        expect(param1).to.deep.equal(
          {intField: 6, stringField: 'int param is 6'});
-      done();
+       done();
     });
   });
 
@@ -53,16 +61,92 @@ describe('Callbacks with', () => {
     callbackTestExtension.callbackWithTwoPrimitiveParams((param0: number, param1: number) => {
        expect(param0).to.equal(777);
        expect(param1).to.equal(888);
-      done();
+       done();
     });
   });
 
-  it('one primitive types and one user defined data typeis called', (done) => {
+  it('one primitive type and one user defined data type is called', (done) => {
     callbackTestExtension.callbackWithPrimitiveAndUddtParams((param0: number, param1: MochaMessage) => {
        expect(param0).to.equal(777);
        expect(param1).to.deep.equal(
         {intField: 42, stringField: 'This is a string'});
-      done();
+       done();
     });
+  });
+
+  it('one primitive type and one array type is called', (done) => {
+    callbackTestExtension.callbackWithPrimitiveAndArrayParams((param0: number, param1: Array<String>) => {
+       expect(param0).to.equal(777);
+       expect(param1).to.deep.equals(["one", "two", "three"]);
+       done();
+    });
+  });
+
+  it('one primitive type and one dictionary type is called', (done) => {
+    callbackTestExtension.callbackWithPrimitiveAndDictionaryParams((param0: number, param1: Object) => {
+       expect(param0).to.equal(777);
+       expect(param1).to.deep.equal({ one: 1, two: 2, three: 3 });
+       done();
+    });
+  });  
+
+  it("one array type and one user defined type is called", done => {
+    callbackTestExtension.callbackWithArrayAndUddtParams(
+      (param0: Array<String>, param1: MochaMessage) => {
+        expect(param0).to.deep.equals(["one", "two", "three"]);
+        expect(param1).to.deep.equal({intField: 42, stringField: 'This is a string'});
+        done();
+      }
+    );
+  });
+
+  it("one array type and one more array type is called", done => {
+    callbackTestExtension.callbackWithArrayAndArrayParams(
+      (param0: Array<String>, param1: Array<String>) => {
+        expect(param0).to.deep.equals(["one", "two", "three"]);
+        expect(param1).to.deep.equals(["four", "five", "six"]);
+        done();
+      }
+    );
+  });
+
+  it("one array type and one dictionary type is called", done => {
+    callbackTestExtension.callbackWithArrayAndDictionaryParams(
+      (param0: Array<String>, param1: Object) => {
+        expect(param0).to.deep.equals(["one", "two", "three"]);
+        expect(param1).to.deep.equal({ one: 1, two: 2, three: 3 });
+        done();
+      }
+    );
+  });
+
+  it("one dictionary type and one user defined type is called", done => {
+    callbackTestExtension.callbackWithDictionaryAndUddtParams(
+      (param0: Object, param1: MochaMessage) => {
+        expect(param0).to.deep.equal({ one: 1, two: 2, three: 3 });
+        expect(param1).to.deep.equal({intField: 42, stringField: 'This is a string'});
+        done();
+      }
+    );
+  });
+
+  it("one dictionary type and one array type is called", done => {
+    callbackTestExtension.callbackWithDictionaryAndArrayParams(
+      (param0: Object, param1: Array<String>) => {
+        expect(param0).to.deep.equal({ one: 1, two: 2, three: 3 });
+        expect(param1).to.deep.equals(["one", "two", "three"]);
+        done();
+      }
+    );
+  });
+
+  it("one dictionary type and one more dictionary type is called", done => {
+    callbackTestExtension.callbackWithDictionaryAndDictionaryParams(
+      (param0: Object, param1: Object) => {
+        expect(param0).to.deep.equal({ one: 1, two: 2, three: 3 });
+        expect(param1).to.deep.equal({ four: 4, five: 5, six: 6 });
+        done();
+      }
+    );
   });
 });

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
@@ -1,9 +1,7 @@
 package com.salesforce.nimbus
 
-
 import org.json.JSONArray
 import org.json.JSONObject
-
 
 @Extension(name = "callbackTestExtension")
 class CallbackTestExtension : NimbusExtension {
@@ -34,11 +32,10 @@ class CallbackTestExtension : NimbusExtension {
     }
 
     @ExtensionMethod
-    fun callbackWithPrimitiveAndArrayParams(arg:(param0: Int, param1: JSONArray) -> Unit) {
+    fun callbackWithPrimitiveAndArrayParams(arg: (param0: Int, param1: JSONArray) -> Unit) {
         var ja = JSONArray(listOf("one", "two", "three"))
         arg(777, ja)
     }
-
 
     @ExtensionMethod
     fun callbackWithPrimitiveAndDictionaryParams(arg: (param0: Int, param1: JSONObject) -> Unit) {

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
@@ -1,5 +1,10 @@
 package com.salesforce.nimbus
 
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+
 @Extension(name = "callbackTestExtension")
 class CallbackTestExtension : NimbusExtension {
     @ExtensionMethod
@@ -26,5 +31,76 @@ class CallbackTestExtension : NimbusExtension {
     @ExtensionMethod
     fun callbackWithPrimitiveAndUddtParams(arg: (param0: Int, param1: MochaTests.MochaMessage) -> Unit) {
         arg(777, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithPrimitiveAndArrayParams(arg:(param0: Int, param1: JSONArray) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(777, ja)
+    }
+
+
+    @ExtensionMethod
+    fun callbackWithPrimitiveAndDictionaryParams(arg: (param0: Int, param1: JSONObject) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(777, jo)
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndUddtParams(arg: (param0: JSONArray, param1: MochaTests.MochaMessage) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(ja, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndArrayParams(arg: (param0: JSONArray, param1: JSONArray) -> Unit) {
+        var ja0 = JSONArray(listOf("one", "two", "three"))
+        var ja1 = JSONArray(listOf("four", "five", "six"))
+        arg(ja0, ja1)
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndDictionaryParams(arg: (param0: JSONArray, param1: JSONObject) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(ja, jo)
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndUddtParams(arg: (param0: JSONObject, param1: MochaTests.MochaMessage) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(jo, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndArrayParams(arg: (param0: JSONObject, param1: JSONArray) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(jo, ja)
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndDictionaryParams(arg: (param0: JSONObject, param1: JSONObject) -> Unit) {
+        var jo0 = JSONObject()
+        jo0.put("one", 1)
+        jo0.put("two", 2)
+        jo0.put("three", 3)
+        var jo1 = JSONObject()
+        jo1.put("four", 4)
+        jo1.put("five", 5)
+        jo1.put("six", 6)
+        arg(jo0, jo1)
     }
 }

--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -5,7 +5,7 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-// swiftlint:disable line_length
+// swiftlint:disable line_length file_length
 
 public protocol Binder {
     associatedtype Target
@@ -36,6 +36,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
@@ -54,11 +72,57 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<CB0: Encodable>(_ function: @escaping (Target) -> (@escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (callable: Callable) -> Void in
             try boundFunction { cb0 in
                 _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> (@escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> (@escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -82,7 +146,137 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<R: Encodable, A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> R, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSDictionary, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -114,6 +308,34 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
@@ -128,7 +350,137 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<R: Encodable, A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> R, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSDictionary, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -160,11 +512,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, CBA0: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -183,6 +675,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
@@ -192,12 +702,39 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void,
-                                                 as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0 in
                 _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -221,7 +758,137 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<R: Encodable, A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> R, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSDictionary, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -239,12 +906,39 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void,
-                                                     as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0 in
                 _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -259,6 +953,118 @@ extension Binder {
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)

--- a/platforms/apple/Sources/Nimbus/Callback.swift
+++ b/platforms/apple/Sources/Nimbus/Callback.swift
@@ -29,22 +29,36 @@ class Callback: Callable {
     }
 
     func call(args: [Any]) throws -> Any {
-        var jsonString: String = "[]"
-        if let encodables = args as? [Encodable] {
-            let jsonEncoder = JSONEncoder()
-            let jsonData = try jsonEncoder.encode(EncodableValue.array(encodables))
-            jsonString = String(data: jsonData, encoding: .utf8)!
-        } else {
-            // Parameters passed to callback are implied that they
-            // conform to Encodable protocol.  If for some reason
-            // any elements don't throw parameter error.
-            throw ParameterError()
+        let jsonEncoder = JSONEncoder()
+        let jsonArgs = try args.map { arg -> String in
+            if let encodable = arg as? Encodable {
+                let jsonData = try jsonEncoder.encode(EncodableValue.value(encodable))
+                let jsonString = String(data: jsonData, encoding: .utf8)!
+                return jsonString
+            } else if arg is NSArray || arg is NSDictionary {
+                // swiftlint:disable:next force_try
+                let data = try! JSONSerialization.data(withJSONObject: arg, options: [])
+                let jsonString = String(data: data, encoding: String.Encoding.utf8)!
+                return jsonString
+            } else {
+                // Parameters passed to callback are implied that they
+                // conform to Encodable protocol or be either NSArray or NSDictionary.
+                // If for some reason any elements don't throw parameter error.
+                throw ParameterError()
+            }
         }
+        let formattedJsonArgs = String(format: "[%@]", jsonArgs.joined(separator: ","))
 
         DispatchQueue.main.async {
             self.webView?.evaluateJavaScript("""
-                var jsonArgs = \(jsonString);
-                mappedJsonArgs = jsonArgs.v;
+                var jsonArgs = \(formattedJsonArgs);
+                var mappedJsonArgs = jsonArgs.map(element => {
+                  if (element.hasOwnProperty('v')) {
+                    return element.v;
+                  } else {
+                    return element;
+                  }
+                });
                 nimbus.callCallback('\(self.callbackId)', mappedJsonArgs);
             """)
         }

--- a/platforms/apple/Sources/Nimbus/EncodableValue.swift
+++ b/platforms/apple/Sources/Nimbus/EncodableValue.swift
@@ -17,7 +17,6 @@ import Foundation
 public enum EncodableValue: Encodable {
     case void
     case value(Encodable)
-    case array([Encodable])
 
     enum Keys: String, CodingKey {
         case v // swiftlint:disable:this identifier_name
@@ -31,11 +30,6 @@ public enum EncodableValue: Encodable {
         case .value(let value):
             let superContainer = container.superEncoder(forKey: .v)
             try value.encode(to: superContainer)
-        case .array(let array):
-            var superContainer = container.nestedUnkeyedContainer(forKey: .v)
-            try array.forEach { encodable in
-                try encodable.encode(to: superContainer.superEncoder())
-            }
         }
     }
 }

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -34,6 +34,22 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some("value"))
     }
 
+    func testBindNullaryWithNSArrayReturn() {
+        binder.bind(BindTarget.nullaryWithNSArrayReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSArray
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSArray
+        XCTAssertEqual(isExpectedType, true)
+    }
+
+    func testBindNullaryWithNSDictionaryReturn() {
+        binder.bind(BindTarget.nullaryWithNSDictionaryReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSDictionary
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSDictionary
+        XCTAssertEqual(isExpectedType, true)
+    }
+
     func testBindNullaryWithReturnThrows() {
         binder.bind(BindTarget.nullaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: []))
@@ -77,6 +93,34 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(42))
+    }
+
+    func testBindUnaryWithNSArrayUnaryCallback() {
+        binder.bind(BindTarget.unaryWithUnaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSArray?
+        let callback: BindTarget.UnaryNSArrayCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one", "two", "three"])
+    }
+
+    func testBindUnaryWithNSDictionaryUnaryCallback() {
+        binder.bind(BindTarget.unaryWithUnaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSDictionary?
+        let callback: BindTarget.UnaryNSDictionaryCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one": 1, "two": 2, "three": 3])
     }
 
     func testBindUnaryWithUnaryCallbackThrows() {
@@ -134,6 +178,30 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some(79))
     }
 
+    func testBindBinaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.binaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 79)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindBinaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.binaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 79)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
     func testBindBinaryWithReturnThrows() throws {
         binder.bind(BindTarget.binaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: [42, 37]))
@@ -152,6 +220,34 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(42))
+    }
+
+    func testBindBinaryWithUnaryNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithUnaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSArray?
+        let callback: BindTarget.UnaryNSArrayCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithUnaryNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithUnaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSDictionary?
+        let callback: BindTarget.UnaryNSDictionaryCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one": 1, "two": 2, "three": 3])
     }
 
     func testBindBinaryWithUnaryCallbackThrows() {
@@ -177,6 +273,142 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(79))
+    }
+    
+    func testBindBinaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindBinaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+    
+    func testBindBinaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+    
+    func testBindBinaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+    
+    func testBindBinaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
     }
 
     func testBindBinaryWithBinaryCallbackThrows() {
@@ -209,6 +441,30 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some(92))
     }
 
+    func testBindTernaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.ternaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 92)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindTernaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.ternaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 92)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
     func testBindTernaryWithReturnThrows() throws {
         binder.bind(BindTarget.ternaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: [42, 37, 13]))
@@ -227,6 +483,34 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(79))
+    }
+    
+    func testBindTernaryWithUnaryNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithUnaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSArray?
+        let callback: BindTarget.UnaryNSArrayCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one", "two", "three"])
+    }
+    
+    func testBindTernaryWithUnaryNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithUnaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSDictionary?
+        let callback: BindTarget.UnaryNSDictionaryCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one": 1, "two": 2, "three": 3])
     }
 
     func testBindTernaryWithUnaryCallbackThrows() {
@@ -252,6 +536,142 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(79))
+    }
+
+    func testBindTernaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindTernaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindTernaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindTernaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+    
+    func testBindTernaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindTernaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+
+    func testBindTernaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+    
+    func testBindTernaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
     }
 
     func testBindTernaryWithBinaryCallbackThrows() {
@@ -284,6 +704,30 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some(99))
     }
 
+    func testBindQuaternaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.quaternaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 99)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindQuaternaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.quaternaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 99)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
     func testBindQuaternaryWithReturnThrows() throws {
         binder.bind(BindTarget.quaternaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: [42, 37, 13, 7]))
@@ -302,6 +746,34 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(92))
+    }
+
+    func testBindQuaternaryWithUnaryNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithUnaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSArray?
+        let callback: BindTarget.UnaryNSArrayCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithUnaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithUnaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSDictionary?
+        let callback: BindTarget.UnaryNSDictionaryCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one": 1, "two": 2, "three": 3])
     }
 
     func testBindQuaternaryWithUnaryCallbackThrows() {
@@ -330,6 +802,142 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(92))
+    }
+
+    func testBindQuaternaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDictionary: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDictionary = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDictionary, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
     }
 
     func testBindQuaternaryWithBinaryCallbackThrows() {
@@ -365,6 +973,30 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some(100))
     }
 
+    func testBindQuinaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.quinaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 100)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindQuinaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.quinaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 100)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
     func testBindQuinaryWithReturnThrows() throws {
         binder.bind(BindTarget.quinaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: [42, 37, 13, 7, 1]))
@@ -383,6 +1015,34 @@ class BinderTests: XCTestCase {
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(result, .some(99))
+    }
+    
+    func testBindQuinaryWithUnaryNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithUnaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSArray?
+        let callback: BindTarget.UnaryNSArrayCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one", "two", "three"])
+    }
+    
+    func testBindQuinaryWithUnaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithUnaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: NSDictionary?
+        let callback: BindTarget.UnaryNSDictionaryCallback = { value in
+            result = value
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, ["one": 1, "two": 2, "three": 3])
     }
 
     func testBindQuinaryWithUnaryCallbackThrows() {
@@ -410,6 +1070,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(99))
     }
 
+    func testBindQuinaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(44))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(44))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindQuinaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.quinaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -431,6 +1227,16 @@ class BindTarget {
 
     typealias UnaryCallback = (Int) -> Void
     typealias BinaryCallback = (Int, Int) -> Void
+    typealias UnaryNSArrayCallback = (NSArray) -> Void
+    typealias UnaryNSDictionaryCallback = (NSDictionary) -> Void
+    typealias BinaryPrimitiveNSArrayCallback = (Int, NSArray) -> Void
+    typealias BinaryPrimitiveNSDictionaryCallback = (Int, NSDictionary) -> Void
+    typealias BinaryNSArrayPrimitiveCallback = (NSArray, Int) -> Void
+    typealias BinaryNSArrayNSArrayCallback = (NSArray, NSArray) -> Void
+    typealias BinaryNSArrayNSDictionaryCallback = (NSArray, NSDictionary) -> Void
+    typealias BinaryNSDictionaryPrimitiveCallback = (NSDictionary, Int) -> Void
+    typealias BinaryNSDictionaryNSArrayCallback = (NSDictionary, NSArray) -> Void
+    typealias BinaryNSDictionaryNSDictionaryCallback = (NSDictionary, NSDictionary) -> Void
 
     func nullaryNoReturn() {
         called = true
@@ -444,6 +1250,16 @@ class BindTarget {
     func nullaryWithReturn() -> String {
         called = true
         return "value"
+    }
+
+    func nullaryWithNSArrayReturn() -> NSArray {
+        called = true
+        return NSArray()
+    }
+
+    func nullaryWithNSDictionaryReturn() -> NSDictionary {
+        called = true
+        return NSDictionary()
     }
 
     func nullaryWithReturnThrows() throws -> String {
@@ -481,9 +1297,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func unaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func unaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func unaryWithBinaryCallback(callback: @escaping BinaryCallback) {
         called = true
         callback(42, 37)
+    }
+
+    func unaryWithBinaryPrimitiveNSArrayCallback(callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(42, arr)
+    }
+
+    func unaryWithBinaryPrimitiveNSDictionaryCallback(callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(42, dict)
+    }
+
+    func unaryWithBinaryNSArrayPrimitiveCallback(callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr, 37)
+    }
+
+    func unaryWithBinaryNSArrayNSArrayCallback(callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func unaryWithBinaryNSArrayNSDictionaryCallback(callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr, dict)
+    }
+
+    func unaryWithBinaryNSDictionaryPrimitiveCallback(callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict, 37)
+    }
+
+    func unaryWithBinaryNSDictionaryNSArrayCallback(callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        callback(dict, arr)
+    }
+
+    func unaryWithBinaryNSDictionaryNSDictionaryCallback(callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func unaryWithBinaryCallbackThrows(callback: @escaping BinaryCallback) throws {
@@ -506,6 +1386,18 @@ class BindTarget {
         return arg0 + arg1
     }
 
+    func binaryWithNSArrayReturn(arg0: Int, arg1: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1]
+        return arr
+    }
+
+    func binaryWithNSDictionaryReturn(arg0: Int, arg1: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1]
+        return dict
+    }
+
     func binaryWithReturnThrows(arg0: Int, arg1: Int) throws -> Int {
         called = true
         throw BindError.boundMethodThrew
@@ -514,6 +1406,18 @@ class BindTarget {
     func binaryWithUnaryCallback(arg0: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0)
+    }
+
+    func binaryWithUnaryNSArrayCallback(arg0: Int, callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func binaryWithUnaryNSDictionaryCallback(arg0: Int, callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
     }
 
     func binaryWithUnaryCallbackThrows(arg0: Int, callback: @escaping UnaryCallback) throws {
@@ -525,6 +1429,58 @@ class BindTarget {
     func binaryWithBinaryCallback(arg0: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, 37)
+    }
+
+    func binaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arg0, arr)
+    }
+
+    func binaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0, dict)
+    }
+
+    func binaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr, 37)
+    }
+
+    func binaryWithBinaryNSArrayNSArrayCallback(arg0: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func binaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr, dict)
+    }
+
+    func binaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict, 37)
+    }
+
+    func binaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        callback(dict, arr)
+    }
+
+    func binaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func binaryWithBinaryCallbackThrows(arg0: Int, callback: @escaping BinaryCallback) throws {
@@ -547,6 +1503,18 @@ class BindTarget {
         return arg0 + arg1 + arg2
     }
 
+    func ternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2]
+        return arr
+    }
+
+    func ternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2]
+        return dict
+    }
+
     func ternaryWithReturnThrows(arg0: Int, arg1: Int, arg2: Int) throws -> Int {
         called = true
         throw BindError.boundMethodThrew
@@ -555,6 +1523,18 @@ class BindTarget {
     func ternaryWithUnaryCallback(arg0: Int, arg1: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1)
+    }
+
+    func ternaryWithUnaryNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func ternaryWithUnaryNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
     }
 
     func ternaryWithUnaryCallbackThrows(arg0: Int, arg1: Int, callback: @escaping UnaryCallback) throws {
@@ -566,6 +1546,58 @@ class BindTarget {
     func ternaryWithBinaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, arg1)
+    }
+
+    func ternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arg0, arr)
+    }
+
+    func ternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0, dict)
+    }
+
+    func ternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr, arg1)
+    }
+
+    func ternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func ternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr, dict)
+    }
+
+    func ternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict, arg1)
+    }
+
+    func ternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        callback(dict, arr)
+    }
+
+    func ternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func ternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) throws {
@@ -588,6 +1620,18 @@ class BindTarget {
         return arg0 + arg1 + arg2 + arg3
     }
 
+    func quaternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2 + arg3]
+        return arr
+    }
+
+    func quaternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3]
+        return dict
+    }
+
     func quaternaryWithReturnThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int) throws -> Int {
         called = true
         throw BindError.boundMethodThrew
@@ -596,6 +1640,18 @@ class BindTarget {
     func quaternaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2)
+    }
+
+    func quaternaryWithUnaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func quaternaryWithUnaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
     }
 
     func quaternaryWithUnaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryCallback) throws {
@@ -607,6 +1663,59 @@ class BindTarget {
     func quaternaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1)
+    }
+
+    func quaternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arg0 + arg2, arr)
+    }
+
+    func quaternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0 + arg2, dict)
+    }
+
+    func quaternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr, arg1)
+    }
+
+    func quaternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func quaternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr, dict)
+    }
+
+    func quaternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict, arg1)
+    }
+
+    func quaternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        callback(dict, arr)
+    }
+
+    func quaternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int,
+                                                              callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func quaternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) throws {
@@ -629,6 +1738,18 @@ class BindTarget {
         return arg0 + arg1 + arg2 + arg3 + arg4
     }
 
+    func quinaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2 + arg3 + arg4]
+        return arr
+    }
+
+    func quinaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3 + arg4]
+        return dict
+    }
+
     func quinaryWithReturnThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) throws -> Int {
         called = true
         throw BindError.boundMethodThrew
@@ -637,6 +1758,18 @@ class BindTarget {
     func quinaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2 + arg3)
+    }
+
+    func quinaryWithUnaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func quinaryWithUnaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
     }
 
     func quinaryWithUnaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryCallback) throws {
@@ -648,6 +1781,63 @@ class BindTarget {
     func quinaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arg0 + arg2, arr)
+    }
+
+    func quinaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int,
+                                                        callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0 + arg2, dict)
+    }
+
+    func quinaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func quinaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int,
+                                                      callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr, dict)
+    }
+
+    func quinaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int,
+                                                        callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int,
+                                                      callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        callback(dict, arr)
+    }
+
+    func quinaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int,
+                                                           callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func quinaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) throws {

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -109,6 +109,42 @@ public class CallbackTestExtension {
     func callbackWithPrimitiveAndUddtParams(completion: @escaping (Int, MochaTests.MochaMessage) -> Swift.Void) {
         completion(777, MochaTests.MochaMessage())
     }
+    func callbackWithPrimitiveAndArrayParams(completion: @escaping (Int, NSArray) -> Swift.Void) {
+        let arr: NSArray = ["one", "two", "three"]
+        completion(777, arr)
+    }
+    func callbackWithPrimitiveAndDictionaryParams(completion: @escaping (Int, NSDictionary) -> Swift.Void) {
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        completion(777, dict)
+    }
+    func callbackWithArrayAndUddtParams(completion: @escaping (NSArray, MochaTests.MochaMessage) -> Swift.Void) {
+        let arr: NSArray = ["one", "two", "three"]
+        completion(arr, MochaTests.MochaMessage())
+    }
+    func callbackWithArrayAndArrayParams(completion: @escaping (NSArray, NSArray) -> Swift.Void) {
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        completion(arr0, arr1)
+    }
+    func callbackWithArrayAndDictionaryParams(completion: @escaping (NSArray, NSDictionary) -> Swift.Void) {
+        let arr: NSArray = ["one", "two", "three"]
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        completion(arr, dict)
+    }
+    func callbackWithDictionaryAndUddtParams(completion: @escaping (NSDictionary, MochaTests.MochaMessage) -> Swift.Void) {
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        completion(dict, MochaTests.MochaMessage())
+    }
+    func callbackWithDictionaryAndArrayParams(completion: @escaping (NSDictionary, NSArray) -> Swift.Void) {
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr: NSArray = ["one", "two", "three"]
+        completion(dict, arr)
+    }
+    func callbackWithDictionaryAndDictionaryParams(completion: @escaping (NSDictionary, NSDictionary) -> Swift.Void) {
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        completion(dict0, dict1)
+    }
 }
 
 extension CallbackTestExtension: NimbusExtension {
@@ -119,5 +155,13 @@ extension CallbackTestExtension: NimbusExtension {
         connection.bind(CallbackTestExtension.callbackWithSinglePrimitiveParam, as: "callbackWithSinglePrimitiveParam")
         connection.bind(CallbackTestExtension.callbackWithTwoPrimitiveParams, as: "callbackWithTwoPrimitiveParams")
         connection.bind(CallbackTestExtension.callbackWithPrimitiveAndUddtParams, as: "callbackWithPrimitiveAndUddtParams")
+        connection.bind(CallbackTestExtension.callbackWithPrimitiveAndArrayParams, as: "callbackWithPrimitiveAndArrayParams")
+        connection.bind(CallbackTestExtension.callbackWithPrimitiveAndDictionaryParams, as: "callbackWithPrimitiveAndDictionaryParams")
+        connection.bind(CallbackTestExtension.callbackWithArrayAndUddtParams, as: "callbackWithArrayAndUddtParams")
+        connection.bind(CallbackTestExtension.callbackWithArrayAndArrayParams, as: "callbackWithArrayAndArrayParams")
+        connection.bind(CallbackTestExtension.callbackWithArrayAndDictionaryParams, as: "callbackWithArrayAndDictionaryParams")
+        connection.bind(CallbackTestExtension.callbackWithDictionaryAndUddtParams, as: "callbackWithDictionaryAndUddtParams")
+        connection.bind(CallbackTestExtension.callbackWithDictionaryAndArrayParams, as: "callbackWithDictionaryAndArrayParams")
+        connection.bind(CallbackTestExtension.callbackWithDictionaryAndDictionaryParams, as: "callbackWithDictionaryAndDictionaryParams")
     }
 }


### PR DESCRIPTION
This is a draft PR to get feedback.

Added support to allow iOS's Foundation type(specifically, `NSArray` and `NSDictionary`) as return type from native methods or as parameters in the callback functions.

In doing so it proliferated unit and mocha tests.  A better approach might have been to encapsulate `NSArray` and `NSDictionary` into an enum, like we do for `EncodableValue`, so a union type could be created.  This way we can reduce matching signatures and consequently the number of tests.  However, I wasn't quite sure if this was possible.  @threeve , we spoke briefly on this bug/enhancement and you were saying you might have an idea on how to approach.  Were you also thinking wrapping the two Foundation types in enum or a class? Please advise and I'll happy to update this PR to reduce the lines of code that were added.