### PR TITLE
Use iOS's Foundation types via sourcery

### DIFF
--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
@@ -1,5 +1,8 @@
 package com.salesforce.nimbus
 
+import org.json.JSONArray
+import org.json.JSONObject
+
 @Extension(name = "callbackTestExtension")
 class CallbackTestExtension : NimbusExtension {
     @ExtensionMethod
@@ -26,5 +29,75 @@ class CallbackTestExtension : NimbusExtension {
     @ExtensionMethod
     fun callbackWithPrimitiveAndUddtParams(arg: (param0: Int, param1: MochaTests.MochaMessage) -> Unit) {
         arg(777, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithPrimitiveAndArrayParams(arg: (param0: Int, param1: JSONArray) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(777, ja)
+    }
+
+    @ExtensionMethod
+    fun callbackWithPrimitiveAndDictionaryParams(arg: (param0: Int, param1: JSONObject) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(777, jo)
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndUddtParams(arg: (param0: JSONArray, param1: MochaTests.MochaMessage) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(ja, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndArrayParams(arg: (param0: JSONArray, param1: JSONArray) -> Unit) {
+        var ja0 = JSONArray(listOf("one", "two", "three"))
+        var ja1 = JSONArray(listOf("four", "five", "six"))
+        arg(ja0, ja1)
+    }
+
+    @ExtensionMethod
+    fun callbackWithArrayAndDictionaryParams(arg: (param0: JSONArray, param1: JSONObject) -> Unit) {
+        var ja = JSONArray(listOf("one", "two", "three"))
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(ja, jo)
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndUddtParams(arg: (param0: JSONObject, param1: MochaTests.MochaMessage) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        arg(jo, MochaTests.MochaMessage())
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndArrayParams(arg: (param0: JSONObject, param1: JSONArray) -> Unit) {
+        var jo = JSONObject()
+        jo.put("one", 1)
+        jo.put("two", 2)
+        jo.put("three", 3)
+        var ja = JSONArray(listOf("one", "two", "three"))
+        arg(jo, ja)
+    }
+
+    @ExtensionMethod
+    fun callbackWithDictionaryAndDictionaryParams(arg: (param0: JSONObject, param1: JSONObject) -> Unit) {
+        var jo0 = JSONObject()
+        jo0.put("one", 1)
+        jo0.put("two", 2)
+        jo0.put("three", 3)
+        var jo1 = JSONObject()
+        jo1.put("four", 4)
+        jo1.put("five", 5)
+        jo1.put("six", 6)
+        arg(jo0, jo1)
     }
 }

--- a/platforms/apple/Sources/Nimbus/Callback.swift
+++ b/platforms/apple/Sources/Nimbus/Callback.swift
@@ -29,22 +29,35 @@ class Callback: Callable {
     }
 
     func call(args: [Any]) throws -> Any {
-        var jsonString: String = "[]"
-        if let encodables = args as? [Encodable] {
-            let jsonEncoder = JSONEncoder()
-            let jsonData = try jsonEncoder.encode(EncodableValue.array(encodables))
-            jsonString = String(data: jsonData, encoding: .utf8)!
-        } else {
-            // Parameters passed to callback are implied that they
-            // conform to Encodable protocol.  If for some reason
-            // any elements don't throw parameter error.
-            throw ParameterError()
+        let jsonEncoder = JSONEncoder()
+        let jsonArgs = try args.map { arg -> String in
+            if let encodable = arg as? Encodable {
+                let jsonData = try jsonEncoder.encode(EncodableValue.value(encodable))
+                let jsonString = String(data: jsonData, encoding: .utf8)!
+                return jsonString
+            } else if arg is NSArray || arg is NSDictionary {
+                let data = try JSONSerialization.data(withJSONObject: arg, options: [])
+                let jsonString = String(data: data, encoding: String.Encoding.utf8)!
+                return jsonString
+            } else {
+                // Parameters passed to callback are implied that they
+                // conform to Encodable protocol or be either NSArray or NSDictionary.
+                // If for some reason any elements don't throw parameter error.
+                throw ParameterError()
+            }
         }
+        let formattedJsonArgs = String(format: "[%@]", jsonArgs.joined(separator: ","))
 
         DispatchQueue.main.async {
             self.webView?.evaluateJavaScript("""
-                var jsonArgs = \(jsonString);
-                mappedJsonArgs = jsonArgs.v;
+                var jsonArgs = \(formattedJsonArgs);
+                var mappedJsonArgs = jsonArgs.map(element => {
+                  if (element.hasOwnProperty('v')) {
+                    return element.v;
+                  } else {
+                    return element;
+                  }
+                });
                 nimbus.callCallback('\(self.callbackId)', mappedJsonArgs);
             """)
         }

--- a/platforms/apple/Sources/Nimbus/EncodableValue.swift
+++ b/platforms/apple/Sources/Nimbus/EncodableValue.swift
@@ -17,7 +17,6 @@ import Foundation
 public enum EncodableValue: Encodable {
     case void
     case value(Encodable)
-    case array([Encodable])
 
     enum Keys: String, CodingKey {
         case v // swiftlint:disable:this identifier_name
@@ -31,11 +30,6 @@ public enum EncodableValue: Encodable {
         case .value(let value):
             let superContainer = container.superEncoder(forKey: .v)
             try value.encode(to: superContainer)
-        case .array(let array):
-            var superContainer = container.nestedUnkeyedContainer(forKey: .v)
-            try array.forEach { encodable in
-                try encodable.encode(to: superContainer.superEncoder())
-            }
         }
     }
 }

--- a/platforms/apple/Sources/Nimbus/Generated/Binders.generated.swift
+++ b/platforms/apple/Sources/Nimbus/Generated/Binders.generated.swift
@@ -8,7 +8,7 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-// swiftlint:disable line_length
+// swiftlint:disable line_length file_length
 
 extension Binder {
 
@@ -25,6 +25,24 @@ extension Binder {
      Bind the specified function to this connection.
      */
     public func bind<R: Encodable>(_ function: @escaping (Target) -> () throws -> R, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSDictionary, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -51,6 +69,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<CB0: Encodable>(_ function: @escaping (Target) -> (@escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (callable: Callable) -> Void in
@@ -65,11 +101,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind(_ function: @escaping (Target) -> (@escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> (@escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (callable: Callable) -> Void in
             try boundFunction { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (callable: Callable) -> Void in
+            try boundFunction { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -97,6 +273,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, CB0: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
@@ -111,11 +305,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
+            try boundFunction(arg0) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -143,6 +477,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
@@ -157,11 +509,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -189,6 +681,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
@@ -203,11 +713,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -235,6 +885,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
@@ -249,11 +917,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<A0, A1, A2, A3, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
+            try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)

--- a/platforms/apple/Sources/Nimbus/Templates/Binders.swifttemplate
+++ b/platforms/apple/Sources/Nimbus/Templates/Binders.swifttemplate
@@ -7,7 +7,7 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-// swiftlint:disable line_length
+// swiftlint:disable line_length file_length
 
 extension Binder {
 <%_  for (index, arity) in arities.enumerated() { -%>
@@ -25,6 +25,24 @@ extension Binder {
      Bind the specified function to this connection.
      */
     public func bind<R: Encodable>(_ function: @escaping (Target) -> () throws -> R, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind(_ function: @escaping (Target) -> () throws -> NSDictionary, as name: String) {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -51,6 +69,24 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSArray, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSDictionary, as name: String) {
+        let boundFunction = function(target)
+        let callable = make_callable(boundFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
@@ -65,11 +101,151 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSArray) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0 in
+                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0 in
+                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cba1 in
+                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cbd1 in
+                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cba1 in
+                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cb1 in
+                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cbd1 in
+                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cb1 in
+                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cba1 in
+                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
+            }
+        }
+        let callable = make_callable(wrappedFunction)
+        bind(callable, as: name)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+        let boundFunction = function(target)
+        let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
+            try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cbd1 in
+                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)

--- a/platforms/apple/Sources/Nimbus/Templates/Utils.swift
+++ b/platforms/apple/Sources/Nimbus/Templates/Utils.swift
@@ -19,6 +19,22 @@ enum FormattingPurpose {
     case forArgsSum
 }
 
+enum FormattingBinaryCallback {
+    case forPrimitiveNSArray
+    case forPrimitiveNSDictionary
+    case forNSArrayPrimitive
+    case forNSArrayNSArray
+    case forNSArrayNSDictionary
+    case forNSDictionaryPrimitive
+    case forNSDictionaryNSArray
+    case forNSDictionaryNSDictionary
+}
+
+enum BinaryCallbackArgPosition {
+    case first
+    case second
+}
+
 func getCommaSeparatedString(count: Int, formattingPurpose: FormattingPurpose) -> String {
     guard count > 0 else {
         fatalError()
@@ -76,6 +92,29 @@ extension Array {
         return total
     }
 
+    func takeAsSumOfBinaryCallback(position: BinaryCallbackArgPosition, count: Int) -> Int {
+        guard let arityArray = self as? [Arity],
+            self.count > 1,
+            count > 0,
+            count <= self.count else {
+                fatalError()
+        }
+
+        var filteredValues = [Int]()
+        for (index, arity) in arityArray[1...].prefix(count).enumerated() {
+            if position == .first {
+                if index % 2 == 0 {
+                    filteredValues.append(arity.testValue)
+                }
+            } else {
+                if index % 2 != 0 {
+                    filteredValues.append(arity.testValue)
+                }
+            }
+        }
+        return filteredValues.reduce(0, +)
+    }
+
     func takeAndMakeParamsWithCallable(count: Int) -> String {
         guard let arityArray = self as? [Arity],
             self.count >= count else {
@@ -127,6 +166,85 @@ extension Array {
             let formattedEven = even.map({(element: Int) in String.init(format: "arg%d", element)}).joined(separator: " + ")
             let formattedOdd = odd.map({(element: Int) in String.init(format: "arg%d", element)}).joined(separator: " + ")
             return String.init(format: "%@, %@", formattedEven, formattedOdd)
+        }
+    }
+
+    // swiftlint:disable function_body_length cyclomatic_complexity
+    func getCallbackArgsForBinaryCallbackWithFoundation(count: Int, formattingPurpose: FormattingBinaryCallback) -> String {
+        guard let arityArray = self as? [Arity],
+            self.count > 1 else {
+                fatalError()
+        }
+        if formattingPurpose == .forNSArrayNSArray {
+            return "arr0, arr1"
+        } else if formattingPurpose == .forNSArrayNSDictionary {
+            return "arr0, dict1"
+        } else if formattingPurpose == .forNSDictionaryNSArray {
+            return "dict0, arr1"
+        } else if formattingPurpose == .forNSDictionaryNSDictionary {
+            return "dict0, dict1"
+        } else {
+            if 1 == count {
+                if formattingPurpose == .forNSArrayPrimitive {
+                    return "arr0, \(arityArray[1...][count+1].testValue)"
+                } else if formattingPurpose == .forNSDictionaryPrimitive {
+                    return "dict0, \(arityArray[1...][count+1].testValue)"
+                } else if formattingPurpose == .forPrimitiveNSArray {
+                    return "\(arityArray[1...][count].testValue), arr1"
+                } else if formattingPurpose == .forPrimitiveNSDictionary {
+                    return "\(arityArray[1...][count].testValue), dict1"
+                } else {
+                    fatalError()
+                }
+            } else if 2 == count {
+                if formattingPurpose == .forNSArrayPrimitive {
+                    return "arr0, \(arityArray[1...][count].testValue)"
+                } else if formattingPurpose == .forNSDictionaryPrimitive {
+                    return "dict0, \(arityArray[1...][count].testValue)"
+                } else if formattingPurpose == .forPrimitiveNSArray {
+                    return "arg0, arr1"
+                } else if formattingPurpose == .forPrimitiveNSDictionary {
+                    return "arg0, dict1"
+                } else {
+                    fatalError()
+                }
+            } else {
+                let forEven = (formattingPurpose == .forPrimitiveNSArray || formattingPurpose == .forPrimitiveNSDictionary)
+                let argIndices = [Int](0...(count - 2))
+                let filteredIndicies = argIndices.filter { (element: Int) -> Bool in
+                    if forEven {
+                        if element % 2 == 0 {
+                            return true
+                        } else {
+                            return false
+                        }
+                    } else {
+                        if element % 2 != 0 {
+                            return true
+                        } else {
+                            return false
+                        }
+                    }
+                }
+
+                let formattedArgs = filteredIndicies.map({(element: Int) in String.init(format: "arg%d", element)}).joined(separator: " + ")
+                var arg = ""
+                if forEven {
+                    if formattingPurpose == .forPrimitiveNSArray {
+                        arg = "arr1"
+                    } else {
+                        arg = "dict1"
+                    }
+                    return String(format: "%@, %@", formattedArgs, arg)
+                } else {
+                    if formattingPurpose == .forNSArrayPrimitive {
+                        arg = "arr0"
+                    } else {
+                        arg = "dict0"
+                    }
+                    return String(format: "%@, %@", arg, formattedArgs)
+                }
+            }
         }
     }
 }

--- a/platforms/apple/Sources/NimbusTests/Generated/BinderTests.generated.swift
+++ b/platforms/apple/Sources/NimbusTests/Generated/BinderTests.generated.swift
@@ -13,7 +13,7 @@ import XCTest
 @testable import Nimbus
 
 // repetitive tests are repetitive...
-// swiftlint:disable type_body_length file_length
+// swiftlint:disable type_body_length file_length line_length
 
 class BinderTests: XCTestCase {
     let binder = TestBinder()
@@ -35,6 +35,22 @@ class BinderTests: XCTestCase {
         let value = try? binder.callable?.call(args: []) as? String
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some("value"))
+    }
+
+    func testBindNullaryWithNSArrayReturn() {
+        binder.bind(BindTarget.nullaryWithNSArrayReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSArray
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSArray
+        XCTAssertEqual(isExpectedType, true)
+    }
+
+    func testBindNullaryWithNSDictionaryReturn() {
+        binder.bind(BindTarget.nullaryWithNSDictionaryReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSDictionary
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSDictionary
+        XCTAssertEqual(isExpectedType, true)
     }
 
     func testBindNullaryWithReturnThrows() {
@@ -60,6 +76,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(42))
+    }
+
+    func testBindUnaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.unaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 42)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindUnaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.unaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 42)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBindUnaryWithReturnThrows() throws {
@@ -107,6 +147,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
+    func testBindUnaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.unaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindUnaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.unaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindUnaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindUnaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindUnaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindUnaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+
+    func testBindUnaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindUnaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.unaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindUnaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.unaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -135,6 +311,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(79))
+    }
+
+    func testBindBinaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.binaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 79)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindBinaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.binaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 79)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBindBinaryWithReturnThrows() throws {
@@ -182,6 +382,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
+    func testBindBinaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindBinaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindBinaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindBinaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+
+    func testBindBinaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindBinaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.binaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindBinaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.binaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -210,6 +546,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(92))
+    }
+
+    func testBindTernaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.ternaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 92)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindTernaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.ternaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 92)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBindTernaryWithReturnThrows() throws {
@@ -257,6 +617,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
+    func testBindTernaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindTernaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(42))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindTernaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindTernaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindTernaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindTernaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+
+    func testBindTernaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindTernaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.ternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindTernaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.ternaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -285,6 +781,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(99))
+    }
+
+    func testBindQuaternaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.quaternaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 99)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindQuaternaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.quaternaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 99)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBindQuaternaryWithReturnThrows() throws {
@@ -332,6 +852,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(92))
     }
 
+    func testBindQuaternaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(37))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindQuaternaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(37))
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuaternaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quaternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindQuaternaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.quaternaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -360,6 +1016,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(100))
+    }
+
+    func testBindQuinaryWithNSArrayReturn() throws {
+        binder.bind(BindTarget.quinaryWithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, 100)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBindQuinaryWithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.quinaryWithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, 100)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBindQuinaryWithReturnThrows() throws {
@@ -407,6 +1087,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(99))
     }
 
+    func testBindQuinaryWithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(55))
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(44))
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, ["one", "two", "three"])
+        XCTAssertEqual(resultArray2, ["four", "five", "six"])
+    }
+
+    func testBindQuinaryWithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(result, .some(44))
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultArray, ["one", "two", "three"])
+    }
+
+    func testBindQuinaryWithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.quinaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
+        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
+    }
+
     func testBindQuinaryWithBinaryCallbackThrows() {
         binder.bind(BindTarget.quinaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -428,6 +1244,16 @@ class BindTarget {
 
     typealias UnaryCallback = (Int) -> Void
     typealias BinaryCallback = (Int, Int) -> Void
+    typealias UnaryNSArrayCallback = (NSArray) -> Void
+    typealias UnaryNSDictionaryCallback = (NSDictionary) -> Void
+    typealias BinaryPrimitiveNSArrayCallback = (Int, NSArray) -> Void
+    typealias BinaryPrimitiveNSDictionaryCallback = (Int, NSDictionary) -> Void
+    typealias BinaryNSArrayPrimitiveCallback = (NSArray, Int) -> Void
+    typealias BinaryNSArrayNSArrayCallback = (NSArray, NSArray) -> Void
+    typealias BinaryNSArrayNSDictionaryCallback = (NSArray, NSDictionary) -> Void
+    typealias BinaryNSDictionaryPrimitiveCallback = (NSDictionary, Int) -> Void
+    typealias BinaryNSDictionaryNSArrayCallback = (NSDictionary, NSArray) -> Void
+    typealias BinaryNSDictionaryNSDictionaryCallback = (NSDictionary, NSDictionary) -> Void
 
     func nullaryNoReturn() {
         called = true
@@ -441,6 +1267,16 @@ class BindTarget {
     func nullaryWithReturn() -> String {
         called = true
         return "value"
+    }
+
+    func nullaryWithNSArrayReturn() -> NSArray {
+        called = true
+        return NSArray()
+    }
+
+    func nullaryWithNSDictionaryReturn() -> NSDictionary {
+        called = true
+        return NSDictionary()
     }
 
     func nullaryWithReturnThrows() throws -> String {
@@ -467,6 +1303,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func unaryWithNSArrayReturn(arg0: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0]
+        return arr
+    }
+
+    func unaryWithNSDictionaryReturn(arg0: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0]
+        return dict
+    }
+
     func unaryWithUnaryCallback(callback: @escaping UnaryCallback) {
         called = true
         callback(42)
@@ -478,9 +1326,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func unaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func unaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func unaryWithBinaryCallback(callback: @escaping BinaryCallback) {
         called = true
         callback(42, 37)
+    }
+
+    func unaryWithBinaryPrimitiveNSArrayCallback(callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(42, arr1)
+    }
+
+    func unaryWithBinaryPrimitiveNSDictionaryCallback(callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(42, dict1)
+    }
+
+    func unaryWithBinaryNSArrayPrimitiveCallback(callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        callback(arr0, 37)
+    }
+
+    func unaryWithBinaryNSArrayNSArrayCallback(callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func unaryWithBinaryNSArrayNSDictionaryCallback(callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr0, dict1)
+    }
+
+    func unaryWithBinaryNSDictionaryPrimitiveCallback(callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict0, 37)
+    }
+
+    func unaryWithBinaryNSDictionaryNSArrayCallback(callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(dict0, arr1)
+    }
+
+    func unaryWithBinaryNSDictionaryNSDictionaryCallback(callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func unaryWithBinaryCallbackThrows(callback: @escaping BinaryCallback) throws {
@@ -508,6 +1420,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func binaryWithNSArrayReturn(arg0: Int, arg1: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1]
+        return arr
+    }
+
+    func binaryWithNSDictionaryReturn(arg0: Int, arg1: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1]
+        return dict
+    }
+
     func binaryWithUnaryCallback(arg0: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0)
@@ -519,9 +1443,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func binaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func binaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func binaryWithBinaryCallback(arg0: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, 37)
+    }
+
+    func binaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(arg0, arr1)
+    }
+
+    func binaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0, dict1)
+    }
+
+    func binaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        callback(arr0, 37)
+    }
+
+    func binaryWithBinaryNSArrayNSArrayCallback(arg0: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func binaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr0, dict1)
+    }
+
+    func binaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict0, 37)
+    }
+
+    func binaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(dict0, arr1)
+    }
+
+    func binaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func binaryWithBinaryCallbackThrows(arg0: Int, callback: @escaping BinaryCallback) throws {
@@ -549,6 +1537,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func ternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2]
+        return arr
+    }
+
+    func ternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2]
+        return dict
+    }
+
     func ternaryWithUnaryCallback(arg0: Int, arg1: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1)
@@ -560,9 +1560,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func ternaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func ternaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func ternaryWithBinaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, arg1)
+    }
+
+    func ternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(arg0, arr1)
+    }
+
+    func ternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0, dict1)
+    }
+
+    func ternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        callback(arr0, arg1)
+    }
+
+    func ternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func ternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr0, dict1)
+    }
+
+    func ternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict0, arg1)
+    }
+
+    func ternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(dict0, arr1)
+    }
+
+    func ternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func ternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) throws {
@@ -590,6 +1654,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func quaternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2 + arg3]
+        return arr
+    }
+
+    func quaternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3]
+        return dict
+    }
+
     func quaternaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2)
@@ -601,9 +1677,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func quaternaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func quaternaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func quaternaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1)
+    }
+
+    func quaternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(arg0 + arg2, arr1)
+    }
+
+    func quaternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0 + arg2, dict1)
+    }
+
+    func quaternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        callback(arr0, arg1)
+    }
+
+    func quaternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func quaternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr0, dict1)
+    }
+
+    func quaternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict0, arg1)
+    }
+
+    func quaternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(dict0, arr1)
+    }
+
+    func quaternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func quaternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) throws {
@@ -631,6 +1771,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func quinaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSArray {
+        called = true
+        let arr: NSArray = [arg0 + arg1 + arg2 + arg3 + arg4]
+        return arr
+    }
+
+    func quinaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3 + arg4]
+        return dict
+    }
+
     func quinaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2 + arg3)
@@ -642,9 +1794,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func quinaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = ["one", "two", "three"]
+        callback(arr)
+    }
+
+    func quinaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict)
+    }
+
     func quinaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(arg0 + arg2, arr1)
+    }
+
+    func quinaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arg0 + arg2, dict1)
+    }
+
+    func quinaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        callback(arr0, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let arr1: NSArray = ["four", "five", "six"]
+        callback(arr0, arr1)
+    }
+
+    func quinaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = ["one", "two", "three"]
+        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(arr0, dict1)
+    }
+
+    func quinaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        callback(dict0, arg1 + arg3)
+    }
+
+    func quinaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let arr1: NSArray = ["one", "two", "three"]
+        callback(dict0, arr1)
+    }
+
+    func quinaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
+        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
+        callback(dict0, dict1)
     }
 
     func quinaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) throws {

--- a/platforms/apple/Sources/NimbusTests/Templates/BinderTests.swifttemplate
+++ b/platforms/apple/Sources/NimbusTests/Templates/BinderTests.swifttemplate
@@ -12,8 +12,13 @@ import XCTest
 @testable import Nimbus
 
 // repetitive tests are repetitive...
-// swiftlint:disable type_body_length file_length
-
+// swiftlint:disable type_body_length file_length line_length
+<%_
+let arr0 = "[\"one\", \"two\", \"three\"]"
+let arr1 = "[\"four\", \"five\", \"six\"]"
+let dict0 = "[\"one\": 1, \"two\": 2, \"three\": 3]"
+let dict1 = "[\"four\": 4, \"five\": 5, \"six\": 6]"
+_%>
 class BinderTests: XCTestCase {
     let binder = TestBinder()
 <%_  for (index, arity) in arities.enumerated() { -%>
@@ -35,6 +40,22 @@ class BinderTests: XCTestCase {
         let value = try? binder.callable?.call(args: []) as? String
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some("value"))
+    }
+
+    func testBindNullaryWithNSArrayReturn() {
+        binder.bind(BindTarget.nullaryWithNSArrayReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSArray
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSArray
+        XCTAssertEqual(isExpectedType, true)
+    }
+
+    func testBindNullaryWithNSDictionaryReturn() {
+        binder.bind(BindTarget.nullaryWithNSDictionaryReturn, as: "")
+        let value = try? binder.callable?.call(args: []) as? NSDictionary
+        XCTAssert(binder.target.called)
+        let isExpectedType = value is NSDictionary
+        XCTAssertEqual(isExpectedType, true)
     }
 
     func testBindNullaryWithReturnThrows() {
@@ -60,6 +81,30 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [<%= arities.takeAsString(count: index) %>]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(<%= arities.takeAsSum(count: index)%>))
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithNSArrayReturn() throws {
+        binder.bind(BindTarget.<%= arity.name %>WithNSArrayReturn, as: "")
+        let value = try binder.callable?.call(args: [<%= arities.takeAsString(count: index) %>]) as? NSArray
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value.firstObject as? Int {
+            XCTAssertEqual(result, <%= arities.takeAsSum(count: index)%>)
+        } else {
+            XCTFail("Value not found")
+        }
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithNSDictionaryReturn() throws {
+        binder.bind(BindTarget.<%= arity.name %>WithNSDictionaryReturn, as: "")
+        let value = try binder.callable?.call(args: [<%= arities.takeAsString(count: index) %>]) as? NSDictionary
+        XCTAssert(binder.target.called)
+        if let value = value,
+            let result = value["result"] as? Int {
+            XCTAssertEqual(result, <%= arities.takeAsSum(count: index)%>)
+        } else {
+            XCTFail("Value not found")
+        }
     }
 
     func testBind<%= arity.name.capitalizingFirstLetter() %>WithReturnThrows() throws {
@@ -107,6 +152,142 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(<%if index > 2 { %><%= arities.takeAsSum(count: index - 1) %><% } else { %><%= arities.takeAsSum(count: 2) %><% } %>))
     }
 
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryPrimitiveNSArrayCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryPrimitiveNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
+            result = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(<% if index > 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index - 1)%><% } else if index == 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index) %><% } else if index == 1 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index + 1) %><% } %>))
+        XCTAssertEqual(resultArray, <%= arr0 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryPrimitiveNSDictionaryCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryPrimitiveNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
+            result = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(<% if index > 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index - 1)%><% } else if index == 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index) %><% } else if index == 1 { %><%= arities.takeAsSumOfBinaryCallback(position: .first, count: index + 1) %><% } %>))
+        XCTAssertEqual(resultDict, <%= dict0 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSArrayPrimitiveCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSArrayPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
+            resultArray = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result, .some(<% if index > 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .second, count: index - 1)%><% } else { %><%= arities.takeAsSumOfBinaryCallback(position: .second, count: index + 1) %><% } %>))
+        XCTAssertEqual(resultArray, <%= arr0 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSArrayNSArrayCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSArrayNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray1: NSArray?
+        var resultArray2: NSArray?
+        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
+            resultArray1 = value1
+            resultArray2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray1, <%= arr0 %>)
+        XCTAssertEqual(resultArray2, <%= arr1 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSArrayNSDictionaryCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSArrayNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultArray: NSArray?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
+            resultArray = value1
+            resultDict = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultArray, <%= arr0 %>)
+        XCTAssertEqual(resultDict, <%= dict0 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSDictionaryPrimitiveCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSDictionaryPrimitiveCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var result: Int?
+        var resultDict: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
+            resultDict = value1
+            result = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, <%= dict0 %>)
+        XCTAssertEqual(result, .some(<% if index > 2 { %><%= arities.takeAsSumOfBinaryCallback(position: .second, count: index - 1)%><% } else { %><%= arities.takeAsSumOfBinaryCallback(position: .second, count: index + 1) %><% } %>))
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSDictionaryNSArrayCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSDictionaryNSArrayCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict: NSDictionary?
+        var resultArray: NSArray?
+        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
+            resultDict = value1
+            resultArray = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict, <%= dict0 %>)
+        XCTAssertEqual(resultArray, <%= arr0 %>)
+    }
+
+    func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryNSDictionaryNSDictionaryCallback() {
+        binder.bind(BindTarget.<%= arity.name %>WithBinaryNSDictionaryNSDictionaryCallback, as: "")
+        let expecter = expectation(description: "callback")
+        var resultDict1: NSDictionary?
+        var resultDict2: NSDictionary?
+        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
+            resultDict1 = value1
+            resultDict2 = value2
+            expecter.fulfill()
+        }
+        _ = try? binder.callable?.call(args: [<%= arities.takeAndMakeParamsWithCallable(count: index)%>])
+        wait(for: [expecter], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(resultDict1, <%= dict0 %>)
+        XCTAssertEqual(resultDict2, <%= dict1 %>)
+    }
+
     func testBind<%= arity.name.capitalizingFirstLetter() %>WithBinaryCallbackThrows() {
         binder.bind(BindTarget.<%= arity.name %>WithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -130,6 +311,16 @@ class BindTarget {
 
     typealias UnaryCallback = (Int) -> Void
     typealias BinaryCallback = (Int, Int) -> Void
+    typealias UnaryNSArrayCallback = (NSArray) -> Void
+    typealias UnaryNSDictionaryCallback = (NSDictionary) -> Void
+    typealias BinaryPrimitiveNSArrayCallback = (Int, NSArray) -> Void
+    typealias BinaryPrimitiveNSDictionaryCallback = (Int, NSDictionary) -> Void
+    typealias BinaryNSArrayPrimitiveCallback = (NSArray, Int) -> Void
+    typealias BinaryNSArrayNSArrayCallback = (NSArray, NSArray) -> Void
+    typealias BinaryNSArrayNSDictionaryCallback = (NSArray, NSDictionary) -> Void
+    typealias BinaryNSDictionaryPrimitiveCallback = (NSDictionary, Int) -> Void
+    typealias BinaryNSDictionaryNSArrayCallback = (NSDictionary, NSArray) -> Void
+    typealias BinaryNSDictionaryNSDictionaryCallback = (NSDictionary, NSDictionary) -> Void
 <%_  for (index, arity) in arities.enumerated() { -%>
 <%_     if index == 0 { _%>
     func nullaryNoReturn() {
@@ -144,6 +335,16 @@ class BindTarget {
     func nullaryWithReturn() -> String {
         called = true
         return "value"
+    }
+
+    func nullaryWithNSArrayReturn() -> NSArray {
+        called = true
+        return NSArray()
+    }
+
+    func nullaryWithNSDictionaryReturn() -> NSDictionary {
+        called = true
+        return NSDictionary()
     }
 
     func nullaryWithReturnThrows() throws -> String {
@@ -171,6 +372,18 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func <%= arity.name %>WithNSArrayReturn(<%= getCommaSeparatedString(count: index, formattingPurpose: .forMethodArgsAsIntDecl) %>) -> NSArray {
+        called = true
+        let arr: NSArray = [<%= getCommaSeparatedString(count: index, formattingPurpose: .forArgsSum) %>]
+        return arr
+    }
+
+    func <%= arity.name %>WithNSDictionaryReturn(<%= getCommaSeparatedString(count: index, formattingPurpose: .forMethodArgsAsIntDecl) %>) -> NSDictionary {
+        called = true
+        let dict: NSDictionary = ["result": <%= getCommaSeparatedString(count: index, formattingPurpose: .forArgsSum) %>]
+        return dict
+    }
+
     func <%= arity.name %>WithUnaryCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping UnaryCallback) {
         called = true
         callback(<%= arities.getCallbackArgsForUnaryCallback(count: index) %>)
@@ -182,9 +395,73 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func <%= arity.name %>WithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
+        called = true
+        let arr: NSArray = <%= arr0 %>
+        callback(arr)
+    }
+
+    func <%= arity.name %>WithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
+        called = true
+        let dict: NSDictionary = <%= dict0 %>
+        callback(dict)
+    }
+
     func <%= arity.name %>WithBinaryCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryCallback) {
         called = true
         callback(<%= arities.getCallbackArgsForBinaryCallback(count: index) %>)
+    }
+
+    func <%= arity.name %>WithBinaryPrimitiveNSArrayCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryPrimitiveNSArrayCallback) {
+        called = true
+        let arr1: NSArray = <%= arr0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forPrimitiveNSArray) %>)
+    }
+
+    func <%= arity.name %>WithBinaryPrimitiveNSDictionaryCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
+        called = true
+        let dict1: NSDictionary = <%= dict0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forPrimitiveNSDictionary) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSArrayPrimitiveCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSArrayPrimitiveCallback) {
+        called = true
+        let arr0: NSArray = <%= arr0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSArrayPrimitive) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSArrayNSArrayCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSArrayNSArrayCallback) {
+        called = true
+        let arr0: NSArray = <%= arr0 %>
+        let arr1: NSArray = <%= arr1 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSArrayNSArray) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSArrayNSDictionaryCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSArrayNSDictionaryCallback) {
+        called = true
+        let arr0: NSArray = <%= arr0 %>
+        let dict1: NSDictionary = <%= dict0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSArrayNSDictionary) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSDictionaryPrimitiveCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
+        called = true
+        let dict0: NSDictionary = <%= dict0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSDictionaryPrimitive) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSDictionaryNSArrayCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSDictionaryNSArrayCallback) {
+        called = true
+        let dict0: NSDictionary = <%= dict0 %>
+        let arr1: NSArray = <%= arr0 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSDictionaryNSArray) %>)
+    }
+
+    func <%= arity.name %>WithBinaryNSDictionaryNSDictionaryCallback(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
+        called = true
+        let dict0: NSDictionary = <%= dict0 %>
+        let dict1: NSDictionary = <%= dict1 %>
+        callback(<%= arities.getCallbackArgsForBinaryCallbackWithFoundation(count: index, formattingPurpose: .forNSDictionaryNSDictionary) %>)
     }
 
     func <%= arity.name %>WithBinaryCallbackThrows(<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forMethodArgsAsIntDecl) %>, <% } %>callback: @escaping BinaryCallback) throws {


### PR DESCRIPTION
This is a follow-up PR to https://github.com/salesforce/nimbus/pull/87.  It brings #87 to equivalent of close PR #85 using Sourcery code generation. The diff between this PR and #87 should suffice to show the slight improvement there in writing repeated, almost similar bind code in iOS and its respective tests.

I did not mix this code generation improvement using Sourcery with currying improvement as I couldn't put together a solution that both improvements would work together.



