### PR TITLE
Enable incremental annotation processing

### DIFF
--- a/platforms/android/nimbus-compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/platforms/android/nimbus-compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+com.salesforce.nimbus.NimbusProcessor,isolating


### PR DESCRIPTION
Fixes #113 

Enables incremental annotation processing for the nimbus-compiler.  Now the output from the compiler is:
```
[INFO] com.salesforce.nimbus.NimbusProcessor: total: 121 ms, init: 35 ms, 3 round(s): 85 ms, 1 ms, 0 ms
```

See https://docs.gradle.org/4.7/userguide/java_plugin.html#sec:incremental_annotation_processing for more information