### PR TITLE
Fix link to Getting Started in topic body.

### DIFF
--- a/docs/site/docs/overview/index.md
+++ b/docs/site/docs/overview/index.md
@@ -6,4 +6,4 @@ layout: docs
 
 Nimbus is a framework for building <a href="{{ '/docs/progressive-hybrid-apps' | url }}">Progressive Hybrid Apps</a>. These apps take advantage of modern web standards in the browser and are enhanced with additional platform capabilities when running in a hybrid app container.
 
-Nimbus can be added to an existing native or hybrid mobile application to enhance its capabilities or used as a container for starting a fresh web project. Visit the <a href="{{ '/docs/getting-started/' | url }}">Getting Started</a> page to learn how to begin using Nimbus.
+Nimbus can be added to an existing native or hybrid mobile application to enhance its capabilities or used as a container for starting a fresh web project. Visit the <a href="{{ '/docs/overview/getting-started/' | url }}">Getting Started</a> page to learn how to begin using Nimbus.


### PR DESCRIPTION
Ran across this while reviewing existing doc. Figured it was worth fixing now, while I'd remember it...