### PR TITLE
Supporting rejected state in a promise.

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -149,7 +149,7 @@ class Nimbus {
   // in the storage
   public resolvePromise = (promiseUuid: string, data: any, error: any) => {
     if (error) {
-      this.promises[promiseUuid].reject(data);
+      this.promises[promiseUuid].reject(error);
     } else {
       this.promises[promiseUuid].resolve(data);
     }

--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -22,6 +22,8 @@ interface CallbackTestExtension {
   promiseWithPrimitive(): Promise<String>;
   promiseWithDictionaryParam(): Promise<MochaMessage>;
   promiseWithMultipleParamsAndDictionaryParam(param0: number, param1: string): Promise<MochaMessage>;
+  promiseRejects(): Promise<MochaMessage>;
+  promiseWithMultipleParamsRejects(param0: number, param1: number): Promise<MochaMessage>;
 }
 
 declare var callbackTestExtension: CallbackTestExtension;
@@ -78,7 +80,7 @@ describe('Callbacks with', () => {
     });
   });
 
-  it('promise called with one string param', (done) => {
+  it('method that returns promise called with one string param', (done) => {
     callbackTestExtension.promiseWithPrimitive().then((result) => {
       expect(result).to.equal("one");
       done();
@@ -97,6 +99,20 @@ describe('Callbacks with', () => {
     callbackTestExtension.promiseWithMultipleParamsAndDictionaryParam(777, "promise made").then((result) => {
       expect(result).to.deep.equal(
         { intField: 777, stringField: 'promise made' });
+      done();
+    });
+  });
+
+  it('promise called and returns in a rejected state.', (done) => {
+    callbackTestExtension.promiseRejects().catch((error) => {
+      expect(error).equals('rejected');
+      done();
+    });
+  });
+
+  it('promise called with multiple param and returns in a rejected state.', (done) => {
+    callbackTestExtension.promiseWithMultipleParamsRejects(777, 888).catch((error) => {
+      expect(error).equals('rejected');
       done();
     });
   });

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestExtension.kt
@@ -117,4 +117,14 @@ class CallbackTestExtension : NimbusExtension {
         var mochaMessage = MochaTests.MochaMessage(param1, param0)
         arg(mochaMessage)
     }
+
+    @ExtensionMethod(trailingClosure = TrailingClosure.PROMISE)
+    fun promiseRejects(arg: (param0: MochaTests.MochaMessage) -> Unit) {
+        throw java.lang.IllegalArgumentException("rejected")
+    }
+
+    @ExtensionMethod(trailingClosure = TrailingClosure.PROMISE)
+    fun promiseWithMultipleParamsRejects(param0: Int, param1: Int, arg: (param0: MochaTests.MochaMessage) -> Unit) {
+        throw java.lang.IllegalArgumentException("rejected")
+    }
 }

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -11,6 +11,10 @@ import Nimbus
 import WebKit
 import XCTest
 
+enum PromiseRejectError: Error, Equatable {
+    case rejected
+}
+
 class MochaTests: XCTestCase, WKNavigationDelegate {
     struct MochaMessage: Encodable {
         var stringField = "This is a string"
@@ -126,6 +130,12 @@ public class CallbackTestExtension {
         mochaMessage.stringField = param1
         completion(mochaMessage)
     }
+    func promiseRejects(completion: @escaping (MochaTests.MochaMessage) -> Swift.Void) throws {
+        throw PromiseRejectError.rejected
+    }
+    func promiseWithMultipleParamsRejects(param0: Int, param1: Int, completion: @escaping (MochaTests.MochaMessage) -> Swift.Void) throws {
+        throw PromiseRejectError.rejected
+    }
 }
 
 extension CallbackTestExtension: NimbusExtension {
@@ -139,5 +149,7 @@ extension CallbackTestExtension: NimbusExtension {
         connection.bind(CallbackTestExtension.promiseWithPrimitive, as: "promiseWithPrimitive", trailingClosure: .promise)
         connection.bind(CallbackTestExtension.promiseWithDictionaryParam, as: "promiseWithDictionaryParam", trailingClosure: .promise)
         connection.bind(CallbackTestExtension.promiseWithMultipleParamsAndDictionaryParam, as: "promiseWithMultipleParamsAndDictionaryParam", trailingClosure: .promise)
+        connection.bind(CallbackTestExtension.promiseRejects, as: "promiseRejects", trailingClosure: .promise)
+        connection.bind(CallbackTestExtension.promiseWithMultipleParamsRejects, as: "promiseWithMultipleParamsRejects", trailingClosure: .promise)
     }
 }


### PR DESCRIPTION
Please see https://github.com/salesforce/nimbus/blob/master/docs/site/rfcs/supportRejectInPromiseByTrailingClosure.md for implementation design decisions.

---
Promise created with a trailing closure now supports a rejected state. When a native method throws a string message will be passed as a parameter.  For iOS that string message will be one of the cases in `enum` that implements `Error`.  For Android that string message will be a string that's passed when creating an instance of `Exception` derived class.  The string message can be 'caught' in Javascript like below.

```javascript
doSomething().catch((errorMsg)=>{console.log(errorMsg);});
```