### PR TITLE
Android: preserve and extend JS objects

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -30,7 +30,7 @@ class Nimbus {
       let extensionNames = JSON.parse(_nimbus.nativeExtensionNames());
       extensionNames.forEach((extension: string) => {
         Object.assign(window, {
-          [extension]: this.promisify(window[`_${extension}`])
+          [extension]: Object.assign(window[extension] || {}, this.promisify(window[`_${extension}`]))
         });
       });
     }

--- a/packages/test-www/test/nimbus-core-tests-setup.ts
+++ b/packages/test-www/test/nimbus-core-tests-setup.ts
@@ -1,0 +1,10 @@
+//
+// Copyright (c) 2020, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+const mochaTestBridge = window.mochaTestBridge || {}
+mochaTestBridge.myProp = "exists";
+export default mochaTestBridge

--- a/packages/test-www/test/nimbus-core-tests.ts
+++ b/packages/test-www/test/nimbus-core-tests.ts
@@ -5,16 +5,19 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-import 'mocha';
+import "mocha";
+import { expect } from "chai";
+import setup from "./nimbus-core-tests-setup";
+import nimbus from "nimbus-bridge";
 
-describe('Foo', () => {
-  it('does something', (done) => {
-    done();
-  });
-});
+setup;
+nimbus;
 
-describe('Bar', () => {
-  it.skip('fails', (done) => {
-    done(new Error("meh"));
+describe("Nimbus JS initialization", () => {
+  it("preserves existing objects", () => {
+    expect(nimbus).to.be.an("object", "nimbus should be an object")
+    expect(window.mochaTestBridge).to.be.an("object", "mochaTestBridge should be an object")
+    expect(window.mochaTestBridge.testsCompleted).to.be.a("function")
+    expect(window.mochaTestBridge.myProp).to.equal("exists", "mochaTestBridge.myProp should still exist")
   });
 });


### PR DESCRIPTION
Fixes #122 

To match the behavior on iOS, this change causes existing JS objects to
be preserved.

E.g. if the sample `DeviceExtension` is added to the NimbusBridge, the
following code should work, as it does on iOS
```js
(function() {

const DeviceExtension = window.DeviceExtension || (window.DeviceExtension = {})

DeviceExtension.doSomethingElse = () => {
  // Once Nimbus is initialized, window.DeviceExtension
  // will have { getDeviceInfo, doSomethingElse }
  DeviceExtension.getDeviceInfo().then(info => {
    console.log(info)
  })
}

})();
```

Prior to this change, the behavior depends on whether the above JS code
executes before or after Nimbus initialization.
With this change, both `getDeviceInfo` and `doSomethingElse` are
always available after initialization, regardless of initialization
order.