### PR TITLE
Nimbus javascript Distribution RFC

### DIFF
--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -59,7 +59,7 @@ Cons:
 
 **1 - New Nimbus Module**
 
-We could add a new module to the Nimbus Android project. This module would contain a single Loader class that would vend the `nimbus.js` source. It would obtain the source with a phase added to the module's gradle script which would download the build artifact from the GitHub release, similar to the above iOS options.
+We could add a new module to the Nimbus Android project. This module would contain a single Loader class that would vend the `nimbus.js` source. At build time, the module would build the nimbus js source locally and include it as a resource in the resulting AAR. This module would also contain utilities to automatically inject the nimbus script into the `<head>` tag of a loading page. Ideally, this behavior would be the default, but also optional for consumers who wish to inject the nimbus js differently.
 
 Pros: 
 - Fairly simple, seems to be idiomatic for the platform

--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -10,7 +10,7 @@ This RFC discusses a number of options to enable this on both iOS and Android.
 
 # iOS
 
-**(1) Podspec with a `prepare_command` step**
+**1 - Podspec with a `prepare_command` step**
 
 ```ruby
 spec.prepare_command = <<-CMD
@@ -27,7 +27,7 @@ Cons:
 - This is not technically the intended use of `prepare_command`
 - Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
-**(2) Podspec with a source specification**
+**2 - Podspec with a source specification**
 
 ```ruby
 spec.source = { :http => 'https://github.com/salesforce/nimbus/archive/0.0.7.zip' }
@@ -41,7 +41,7 @@ Pros:
 Cons: 
 - Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
-**(3) Podspec with a script phase**
+**3 - Podspec with a script phase**
 
 ```ruby
 spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
@@ -57,7 +57,7 @@ Cons:
 
 # Android
 
-**(1) New Nimbus Module**
+**1 - New Nimbus Module**
 
 We could add a new module to the Nimbus Android project. This module would contain a single Loader class that would vend the `nimbus.js` source. It would obtain the source with a phase added to the module's gradle script which would download the build artifact from the GitHub release, similar to the above iOS options.
 

--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -2,7 +2,7 @@
 
 In order for nimbus to work, the `nimbus.js` file that is the build output of the TypeScript project has to be present as a resource in any webpage that wants to use hybrid features. 
 
-The current, officially supported way that we do this is to add nimbus as an npm dependency on the web app and load `nimbus.js` in the page itself. This works in some cases, but there are many valid use cases that would be better suited to loading `nimbus.js` as a user script by a hybrid container itself.
+The current, officially supported way that we do this is to add nimbus as an npm dependency on the web app and load `nimbus.js` in the page itself. This is not a perfect solution, as it could lead to native containers getting out of sync with the version of nimbus loaded in the webview. Most use cases would be better suited to loading `nimbus.js` from the hybrid container itself.
 
 We don't currently have any officially supported way for native consumers to import this compiled artifact. Current consumers are building the source themselves and manually copying it into their projects.
 
@@ -27,13 +27,15 @@ Cons:
 - This is not technically the intended use of `prepare_command`
 - Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
-**2 - Podspec with a source specification**
+**2 - Podspec with a source specification - Preferred Option**
 
 ```ruby
 spec.source = { :http => 'https://github.com/salesforce/nimbus/archive/0.0.7.zip' }
 ```
 
 The `source` [specification](https://guides.cocoapods.org/syntax/podspec.html#source) in a podspec can point to a zip file, which is automatically unzipped and the resulting files compose the pod source. This would be the simplest pod, in that we're using `source` for exactly what it's intended. It would require us to amend our workflow when publishing releases.
+
+This new pod, which contains just the `nimbus.js` source, would be added as a dependency in the main nimbus podspec. We would then create convenvience utilities to inject the nimbus source into a `WKWebView` instance as a `WKUserScript`. This would simplify nimbus adoption for most consumers.
 
 Pros: 
 - Easy, and uses podspec source tag for exactly what it's intended for.

--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -1,0 +1,53 @@
+# Distributing nimbus.js to native consumers
+
+In order for nimbus to work, the `nimbus.js` file that is the build output of the TypeScript project has to be present as a resource in any webpage that wants to use hybrid features. 
+
+The current, officially supported way that we do this is to add nimbus as an npm dependency on the web app and load `nimbus.js` in the page itself. This works in some cases, but there are many valid use cases that would be better suited to loading `nimbus.js` as a user script by a hybrid container itself.
+
+We don't currently have any officially supported way for native consumers to import this compiled artifact. Current consumers are either building the source themselves or copying it out of the github releases artifacts and manually copying it into their projects.
+
+This RFC discusses a number of options to enable this on both iOS and Android.
+
+# iOS
+
+**(1) Podspec with a `prepare_command` step**
+
+```ruby
+spec.prepare_command = <<-CMD
+                        # curl and unzip here
+                   CMD
+```
+
+`prepare_command` is fairly stable and well supported, documentation [here](https://guides.cocoapods.org/syntax/podspec.html#prepare_command). The command step would pull the nimbus.js artifact from the GitHub releases page. We don't currently publish the compiled nimbus.js to the releases page, this option would require us to. The resulting file would then be included in the pod as a resource that could then be included in consumer app targets.
+
+Pros: Flexible
+
+Cons: This is not technically the intended use of `prepare_command`
+
+**(2) Podspec with a source specification**
+
+```ruby
+spec.source = { :http => 'https://github.com/salesforce/nimbus/archive/0.0.7.zip' }
+```
+
+The `source` [specification](https://guides.cocoapods.org/syntax/podspec.html#source) in a podspec can point to a zip file, which is automatically unzipped and the resulting files compose the pod source. This would be the simplest pod, in that we're using `source` for exactly what it's intended. It would require us to amend our workflow when publishing releases.
+
+Pros: Easy, and uses podspec source tag for exactly what its intended for.
+
+Cons: Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
+
+**(3) Podspec with a script phase**
+
+```ruby
+spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
+```
+the `script_phase` [specification](https://guides.cocoapods.org/syntax/podspec.html#script_phases) allows a pod author to include a script phase to add to the workspace build settings. We could use this to download the artifact zip and add the nimbus code as a source file. I mostly include this option for completeness as it has considerable downsides and no discernible upsides.
+
+Pros: Flexible
+
+Cons: Causes a warning in the `pod install` process. Invasive to consumers.
+
+# Android
+
+TODO
+

--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -8,6 +8,8 @@ We don't currently have any officially supported way for native consumers to imp
 
 This RFC discusses a number of options to enable this on both iOS and Android.
 
+**The decision is to move forward with Option 2 for iOS and the single proposed option on Android**
+
 # iOS
 
 **1 - Podspec with a `prepare_command` step**
@@ -27,7 +29,7 @@ Cons:
 - This is not technically the intended use of `prepare_command`
 - Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
-**2 - Podspec with a source specification - Preferred Option**
+**2 - Podspec with a source specification - Chosen Option**
 
 ```ruby
 spec.source = { :http => 'https://github.com/salesforce/nimbus/archive/0.0.7.zip' }
@@ -59,7 +61,7 @@ Cons:
 
 # Android
 
-**1 - New Nimbus Module**
+**1 - New Nimbus Module - Chosen Option**
 
 We could add a new module to the Nimbus Android project. This module would contain a single Loader class that would vend the `nimbus.js` source. At build time, the module would build the nimbus js source locally and include it as a resource in the resulting AAR. This module would also contain utilities to automatically inject the nimbus script into the `<head>` tag of a loading page. Ideally, this behavior would be the default, but also optional for consumers who wish to inject the nimbus js differently.
 

--- a/docs/site/rfcs/nimbusJSDistribution.md
+++ b/docs/site/rfcs/nimbusJSDistribution.md
@@ -4,7 +4,7 @@ In order for nimbus to work, the `nimbus.js` file that is the build output of th
 
 The current, officially supported way that we do this is to add nimbus as an npm dependency on the web app and load `nimbus.js` in the page itself. This works in some cases, but there are many valid use cases that would be better suited to loading `nimbus.js` as a user script by a hybrid container itself.
 
-We don't currently have any officially supported way for native consumers to import this compiled artifact. Current consumers are either building the source themselves or copying it out of the github releases artifacts and manually copying it into their projects.
+We don't currently have any officially supported way for native consumers to import this compiled artifact. Current consumers are building the source themselves and manually copying it into their projects.
 
 This RFC discusses a number of options to enable this on both iOS and Android.
 
@@ -20,9 +20,12 @@ spec.prepare_command = <<-CMD
 
 `prepare_command` is fairly stable and well supported, documentation [here](https://guides.cocoapods.org/syntax/podspec.html#prepare_command). The command step would pull the nimbus.js artifact from the GitHub releases page. We don't currently publish the compiled nimbus.js to the releases page, this option would require us to. The resulting file would then be included in the pod as a resource that could then be included in consumer app targets.
 
-Pros: Flexible
+Pros: 
+- Flexible and wouldn't need to have any complicated logic to make sure the script isn't running too often, since it only gets executed once during `pod install`
 
-Cons: This is not technically the intended use of `prepare_command`
+Cons: 
+- This is not technically the intended use of `prepare_command`
+- Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
 **(2) Podspec with a source specification**
 
@@ -32,9 +35,11 @@ spec.source = { :http => 'https://github.com/salesforce/nimbus/archive/0.0.7.zip
 
 The `source` [specification](https://guides.cocoapods.org/syntax/podspec.html#source) in a podspec can point to a zip file, which is automatically unzipped and the resulting files compose the pod source. This would be the simplest pod, in that we're using `source` for exactly what it's intended. It would require us to amend our workflow when publishing releases.
 
-Pros: Easy, and uses podspec source tag for exactly what its intended for.
+Pros: 
+- Easy, and uses podspec source tag for exactly what it's intended for.
 
-Cons: Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
+Cons: 
+- Requires a non-trivial amount of effort to publish artifacts or automate releases (which we should probably do anyway)
 
 **(3) Podspec with a script phase**
 
@@ -43,11 +48,21 @@ spec.script_phase = { :name => 'Hello World', :script => 'echo "Hello World"' }
 ```
 the `script_phase` [specification](https://guides.cocoapods.org/syntax/podspec.html#script_phases) allows a pod author to include a script phase to add to the workspace build settings. We could use this to download the artifact zip and add the nimbus code as a source file. I mostly include this option for completeness as it has considerable downsides and no discernible upsides.
 
-Pros: Flexible
+Pros: 
+- Flexible
 
-Cons: Causes a warning in the `pod install` process. Invasive to consumers.
+Cons: 
+- Causes a warning in the `pod install` process. Invasive to consumers.
+- Need to rely on Xcode features to not run this build phase more often than needed.
 
 # Android
 
-TODO
+**(1) New Nimbus Module**
 
+We could add a new module to the Nimbus Android project. This module would contain a single Loader class that would vend the `nimbus.js` source. It would obtain the source with a phase added to the module's gradle script which would download the build artifact from the GitHub release, similar to the above iOS options.
+
+Pros: 
+- Fairly simple, seems to be idiomatic for the platform
+
+Cons: 
+- Adds complication to the project and is another module for consumers to import.


### PR DESCRIPTION
We don't currently have a good option for native consumers to retrieve a built, versioned copy of the nimbus js to inject from the native side. The need to inject nimbus from native seems like a valid use case, both for production and testing, and is something we should support for a 1.0 of Nimbus.

This RFC provides 3 slightly different options for iOS. I have a preference but I don't want to skew any opinions yet.

There is only a single option for Android, because I don't have much experience at all on Android and it seemed straightforward. This would be the area I would like feedback on the most, and any other options that I haven't thought of for Android would be appreciated.