### PR TITLE
Automate release creation and artifact publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,11 +149,11 @@ jobs:
           at: workspace
 
       - run: |
-          if [ -z ${CIRCLE_TAG+x} ]
+          if [ -z ${HYPE_GITHUB_TOKEN+x} ]
           then
-            echo "circle tag not set"
+            echo "github token not set"
           else
-            echo "tag is $CIRCLE_TAG"
+            echo "token set"
           fi
           which ghr
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           working_directory: platforms/apple
           command: |
             gem install bundler -v 2.0.1
-            bundle install
+            bundle install --path .bundle
             bundle exec pod install
 
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,14 +148,10 @@ jobs:
       - attach_workspace:
           at: workspace
 
-      - run: |
-          if [ -z ${HYPE_GITHUB_TOKEN+x} ]
-          then
-            echo "github token not set"
-          else
-            echo "token set"
-          fi
-          which ghr
+      - run:
+          name: "Create GitHub Release"
+          command: |
+            ghr -t ${HYPE_GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG} ./workspace/NimbusJS.zip
 
   build-and-test-android:
     docker:
@@ -214,10 +210,15 @@ workflows:
   build-and-test:
     jobs:
       - build-and-test-ios
-      #- build-and-test-macos
-      #- build-swiftpm
-      #- build-and-test-android
-      #- build-and-test-ts
+      - build-and-test-macos
+      - build-swiftpm
+      - build-and-test-android
+      - build-and-test-ts
       - create-tagged-release:
           requires:
             - build-and-test-ios
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,16 +20,6 @@ jobs:
           name: Set Ruby Version
           command: echo "ruby-2.5.3" > ~/.ruby-version
 
-      - restore_cache:
-          keys:
-            - v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
-            - v1-pods
-
-      - restore_cache:
-          keys:
-            - v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
-            - v1-bundler
-
       - run:
           name: CocoaPods
           working_directory: platforms/apple
@@ -37,16 +27,6 @@ jobs:
             gem install bundler -v 2.0.1
             bundle install
             bundle exec pod install
-
-      - save_cache:
-          paths:
-            - ./platforms/apple/Pods
-          key: v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
-
-      - save_cache:
-          paths:
-            - ./platforms/apple/.bundle
-          key: v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
 
       - run:
           name: Build macOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,16 @@ jobs:
           name: Set Ruby Version
           command: echo "ruby-2.5.3" > ~/.ruby-version
 
+      - restore_cache:
+          keys:
+            - v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
+            - v1-pods
+
+      - restore_cache:
+          keys:
+            - v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
+            - v1-bundler
+
       - run:
           name: CocoaPods
           working_directory: platforms/apple
@@ -27,6 +37,16 @@ jobs:
             gem install bundler -v 2.0.1
             bundle install
             bundle exec pod install
+
+      - save_cache:
+          paths:
+            - ./platforms/apple/Pods
+          key: v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
+
+      - save_cache:
+          paths:
+            - ./platforms/apple/.bundle
+          key: v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
 
       - run:
           name: Build macOS
@@ -38,7 +58,7 @@ jobs:
           working_directory: platforms/apple
           command: |
             xcodebuild build -workspace Nimbus.xcworkspace -scheme 'Generate Code from Templates'
-            git diff-index --quiet HEAD
+            git diff-index --quiet HEAD Sources
 
   build-swiftpm:
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,13 +81,13 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-pods-{{ checksum "Podfile.lock" }}
+            - v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
             - v1-pods
 
-      - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      #- run:
+         # name: Fetch CocoaPods Specs
+         # command: |
+         #   curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
 
       - run:
           name: CocoaPods
@@ -99,8 +99,8 @@ jobs:
 
       - save_cache:
           paths:
-            - ./Pods
-          key: v1-pods-{{ checksum "Podfile.lock" }}
+            - ./platforms/apple/Pods
+          key: v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
 
       - run:
           name: Build iOS
@@ -130,9 +130,21 @@ jobs:
             npm install
             ./create-nimbus-js.sh
 
-      - store_artifacts:
-          path: NimbusJS.zip
-          destination: NimbusJS.zip
+      - persist_to_workspace:
+          root: .
+          paths:
+            - NimbusJS.zip
+
+  create-tagged-release:
+    docker:
+      - image: cibuilds/github:0.10
+
+    steps:
+      - attach_workspace:
+          at: workspace
+
+      - run: |
+          git describe --tags
 
   build-and-test-android:
     docker:
@@ -191,7 +203,10 @@ workflows:
   build-and-test:
     jobs:
       - build-and-test-ios
-      - build-and-test-macos
-      - build-swiftpm
-      - build-and-test-android
-      - build-and-test-ts
+      #- build-and-test-macos
+      #- build-swiftpm
+      #- build-and-test-android
+      #- build-and-test-ts
+      - create-tagged-release:
+          requires:
+            - build-and-test-ios

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,11 @@ jobs:
           name: Set Ruby Version
           command: echo "ruby-2.5.3" > ~/.ruby-version
 
+      - restore_cache:
+          keys:
+            - v1-pods-{{ checksum "Podfile.lock" }}
+            - v1-pods
+
       - run:
           name: Fetch CocoaPods Specs
           command: |
@@ -91,6 +96,11 @@ jobs:
             gem install bundler -v 2.0.1
             bundle install
             bundle exec pod install
+
+      - save_cache:
+          paths:
+            - ./Pods
+          key: v1-pods-{{ checksum "Podfile.lock" }}
 
       - run:
           name: Build iOS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,23 +84,28 @@ jobs:
             - v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
             - v1-pods
 
-      #- run:
-         # name: Fetch CocoaPods Specs
-         # command: |
-         #   curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - restore_cache:
+          keys:
+            - v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
+            - v1-bundler
 
       - run:
           name: CocoaPods
           working_directory: platforms/apple
           command: |
             gem install bundler -v 2.0.1
-            bundle install
+            bundle install --path .bundle
             bundle exec pod install
 
       - save_cache:
           paths:
             - ./platforms/apple/Pods
           key: v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
+
+      - save_cache:
+          paths:
+            - ./platforms/apple/.bundle
+          key: v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
 
       - run:
           name: Build iOS
@@ -144,7 +149,13 @@ jobs:
           at: workspace
 
       - run: |
-          git describe --tags
+          if [ -z ${CIRCLE_TAG+x} ]
+          then
+            echo "circle tag not set"
+          else
+            echo "tag is $CIRCLE_TAG"
+          fi
+          which ghr
 
   build-and-test-android:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,15 @@ jobs:
           name: Set Ruby Version
           command: echo "ruby-2.5.3" > ~/.ruby-version
 
-      - run:
-          name: Fetch CocoaPods Specs
-          command: |
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - restore_cache:
+          keys:
+            - v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
+            - v1-pods
+
+      - restore_cache:
+          keys:
+            - v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
+            - v1-bundler
 
       - run:
           name: CocoaPods
@@ -32,6 +37,16 @@ jobs:
             gem install bundler -v 2.0.1
             bundle install
             bundle exec pod install
+
+      - save_cache:
+          paths:
+            - ./platforms/apple/Pods
+          key: v1-pods-{{ checksum "platforms/apple/Podfile.lock" }}
+
+      - save_cache:
+          paths:
+            - ./platforms/apple/.bundle
+          key: v1-bundler-{{ checksum "platforms/apple/Gemfile.lock" }}
 
       - run:
           name: Build macOS


### PR DESCRIPTION
This adds a new job to create a release on GitHub when a new tag is pushed.

This also adds some optimizations to the iOS build and test job.