### PR TITLE
Add job for creating and uploading Android distribution binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,6 +244,19 @@ jobs:
           command: |
             bash <(curl -s https://codecov.io/bash) -f ./workspace/platforms/android/nimbus/build/reports/jacoco/jacocoTestDebugUnitTestReport/jacocoTestDebugUnitTestReport.xml
 
+  upload-android-release:
+    docker:
+      - image: circleci/android:api-29-node
+
+    steps:
+      - checkout
+
+      - run:
+          name: Build and upload Android distribution binaries to Bintray
+          working_directory: platforms/android
+          command: |
+            ./gradlew bintrayUpload
+
 workflows:
   version: 2
   build-and-test:
@@ -260,6 +273,14 @@ workflows:
       - create-tagged-release:
           requires:
             - build-and-test-ios
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
+      - upload-android-release:
+          requires:
+            - build-and-test-android
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
This creates a job, downstream from the android build and test, which only runs when a new tag is pushed (similar to the iOS job). This job runs the Bintray upload gradle task. I've added a user name and API key to Bintray to the circle ci project environment variables. From what I can tell, these are the only variables used by the distribution task not defined in the gradle file itself, but please correct me if I'm mistaken.