### PR TITLE
Allow parameters to a Callable that conform to Decodable

### DIFF
--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		68FA8B8B233DE57500682431 /* Binders.swifttemplate in Resources */ = {isa = PBXBuildFile; fileRef = 68FA8B87233DE57500682431 /* Binders.swifttemplate */; };
 		68FA8B94233DEAF500682431 /* Binders.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FA8B91233DEAE900682431 /* Binders.generated.swift */; };
 		68FA8B95233DEAF900682431 /* Callables.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FA8B90233DEAE900682431 /* Callables.generated.swift */; };
+		CC251496240D6764001E8D8C /* DecodableUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC251495240D6764001E8D8C /* DecodableUtils.swift */; };
+		CC251498240D6C13001E8D8C /* DecodableUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC251497240D6C13001E8D8C /* DecodableUtilsTests.swift */; };
 		CC4AB48A23E4919D00DC0613 /* testJSSource.js in Resources */ = {isa = PBXBuildFile; fileRef = CC4AB48723E48DDB00DC0613 /* testJSSource.js */; };
 		CC97224623E4834400F899E7 /* NimbusJS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC97223D23E4834400F899E7 /* NimbusJS.framework */; };
 		CC97224D23E4834400F899E7 /* NimbusJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97224C23E4834400F899E7 /* NimbusJSTests.swift */; };
@@ -227,6 +229,8 @@
 		68FA8B88233DE57500682431 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		68FA8B90233DEAE900682431 /* Callables.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Callables.generated.swift; sourceTree = "<group>"; };
 		68FA8B91233DEAE900682431 /* Binders.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Binders.generated.swift; sourceTree = "<group>"; };
+		CC251495240D6764001E8D8C /* DecodableUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableUtils.swift; sourceTree = "<group>"; };
+		CC251497240D6C13001E8D8C /* DecodableUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodableUtilsTests.swift; sourceTree = "<group>"; };
 		CC4AB48723E48DDB00DC0613 /* testJSSource.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = testJSSource.js; sourceTree = "<group>"; };
 		CC97223D23E4834400F899E7 /* NimbusJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NimbusJS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC97223F23E4834400F899E7 /* NimbusJS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NimbusJS.h; sourceTree = "<group>"; };
@@ -381,6 +385,7 @@
 				291A85FC21E5302C00510832 /* NimbusBridge.swift */,
 				291A85FD21E5302C00510832 /* NimbusExtension.swift */,
 				294433432200FA3700E6D084 /* WebView+Nimbus.swift */,
+				CC251495240D6764001E8D8C /* DecodableUtils.swift */,
 			);
 			name = Nimbus;
 			path = Sources/Nimbus;
@@ -396,6 +401,7 @@
 				294433562200FD8D00E6D084 /* Info.plist */,
 				29245EE1220CE13000F9EEAF /* MochaTests.swift */,
 				29F3839B234BC61000BF854B /* ParameterErrorTests.swift */,
+				CC251497240D6C13001E8D8C /* DecodableUtilsTests.swift */,
 			);
 			name = NimbusTests;
 			path = Sources/NimbusTests;
@@ -998,6 +1004,7 @@
 				294433482200FA3700E6D084 /* WebView+Nimbus.swift in Sources */,
 				2944334B2200FA3700E6D084 /* Connection.swift in Sources */,
 				294433492200FA3700E6D084 /* EncodableValue.swift in Sources */,
+				CC251496240D6764001E8D8C /* DecodableUtils.swift in Sources */,
 				294433472200FA3700E6D084 /* Callback.swift in Sources */,
 				2944334A2200FA3700E6D084 /* Callable.swift in Sources */,
 				68FA8B95233DEAF900682431 /* Callables.generated.swift in Sources */,
@@ -1015,6 +1022,7 @@
 				682D46B5234160650049B636 /* CallableTests.generated.swift in Sources */,
 				68C06580233EE8A200739292 /* Utils.swift in Sources */,
 				68B855F2233EE7FD00D1F243 /* BinderTests.generated.swift in Sources */,
+				CC251498240D6C13001E8D8C /* DecodableUtilsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -893,7 +893,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Pods/Sourcery/bin/sourcery \\\n  --sources ./Sources/Nimbus \\\n  --output ./Sources/Nimbus/Generated \\\n  --templates ./Sources/Nimbus/Templates\n";
+			shellScript = "./Pods/Sourcery/bin/sourcery \\\n  --sources ./Sources/Nimbus \\\n  --output ./Sources/Nimbus/Generated \\\n  --templates ./Sources/Nimbus/Templates --disableCache\n";
 			showEnvVarsInLog = 0;
 		};
 		29397AFC239830A60005F2F7 /* Generate Tests */ = {

--- a/platforms/apple/Sources/Nimbus/DecodableUtils.swift
+++ b/platforms/apple/Sources/Nimbus/DecodableUtils.swift
@@ -1,0 +1,29 @@
+//
+//  DecodableUtils.swift
+//  Nimbus
+//
+//  Created by Paul Tiarks on 3/2/20.
+//  Copyright © 2020 Salesforce.com, inc. All rights reserved.
+//
+
+import Foundation
+
+private extension Decodable {
+    static func openedJSONDecode(using decoder: JSONDecoder, from data: Data) throws -> Self {
+        return try decoder.decode(self, from: data)
+    }
+}
+
+func decodeJSON<A>(_ data: Data, destinationType: A.Type) -> A? {
+    guard let codableType = A.self as? Decodable.Type  else {
+        return nil
+    }
+    var returnValue: A?
+    do {
+        let decoded = try codableType.openedJSONDecode(using: JSONDecoder(), from: data) as! A // swiftlint:disable:this force_cast
+        returnValue = decoded
+        return returnValue
+    } catch {
+        return nil
+    }
+}

--- a/platforms/apple/Sources/Nimbus/Generated/Binders.generated.swift
+++ b/platforms/apple/Sources/Nimbus/Generated/Binders.generated.swift
@@ -53,7 +53,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> Void, as name: String) {
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -62,7 +62,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, A0>(_ function: @escaping (Target) -> (A0) throws -> R, as name: String) {
+    public func bind<R: Encodable, A0>(_ function: @escaping (Target) -> (A0) throws -> R, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -71,7 +71,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSArray, as name: String) {
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSArray, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -80,7 +80,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSDictionary, as name: String) {
+    public func bind<A0>(_ function: @escaping (Target) -> (A0) throws -> NSDictionary, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -257,7 +257,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> Void, as name: String) {
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -266,7 +266,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> R, as name: String) {
+    public func bind<R: Encodable, A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> R, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -275,7 +275,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSArray, as name: String) {
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -284,7 +284,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSDictionary, as name: String) {
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -293,7 +293,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CB0: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CB0: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0 in
@@ -307,7 +307,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cba0 in
@@ -321,7 +321,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+    public func bind<A0>(_ function: @escaping (Target) -> (A0, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cbd0 in
@@ -335,7 +335,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0, cb1 in
@@ -349,7 +349,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0, cba1 in
@@ -363,7 +363,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cb0, cbd1 in
@@ -377,7 +377,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cba0, cba1 in
@@ -391,7 +391,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cba0, cb1 in
@@ -405,7 +405,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cba0, cbd1 in
@@ -419,7 +419,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cbd0, cb1 in
@@ -433,7 +433,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cbd0, cba1 in
@@ -447,7 +447,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try boundFunction(arg0) { cbd0, cbd1 in
@@ -461,7 +461,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -470,7 +470,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> R, as name: String) {
+    public func bind<R: Encodable, A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> R, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -479,7 +479,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSArray, as name: String) {
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -488,7 +488,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSDictionary, as name: String) {
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -497,7 +497,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0 in
@@ -511,7 +511,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cba0 in
@@ -525,7 +525,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1>(_ function: @escaping (Target) -> (A0, A1, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cbd0 in
@@ -539,7 +539,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cb1 in
@@ -553,7 +553,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cba1 in
@@ -567,7 +567,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cb0, cbd1 in
@@ -581,7 +581,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cba0, cba1 in
@@ -595,7 +595,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cba0, cb1 in
@@ -609,7 +609,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cba0, cbd1 in
@@ -623,7 +623,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cbd0, cb1 in
@@ -637,7 +637,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cbd0, cba1 in
@@ -651,7 +651,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try boundFunction(arg0, arg1) { cbd0, cbd1 in
@@ -665,7 +665,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -674,7 +674,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> R, as name: String) {
+    public func bind<R: Encodable, A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> R, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -683,7 +683,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSArray, as name: String) {
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -692,7 +692,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSDictionary, as name: String) {
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -701,7 +701,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0 in
@@ -715,7 +715,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cba0 in
@@ -729,7 +729,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cbd0 in
@@ -743,7 +743,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0, cb1 in
@@ -757,7 +757,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0, cba1 in
@@ -771,7 +771,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cb0, cbd1 in
@@ -785,7 +785,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cba0, cba1 in
@@ -799,7 +799,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cba0, cb1 in
@@ -813,7 +813,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cba0, cbd1 in
@@ -827,7 +827,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cbd0, cb1 in
@@ -841,7 +841,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cbd0, cba1 in
@@ -855,7 +855,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2) { cbd0, cbd1 in
@@ -869,7 +869,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -878,7 +878,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> R, as name: String) {
+    public func bind<R: Encodable, A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> R, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -887,7 +887,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSArray, as name: String) {
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -896,7 +896,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSDictionary, as name: String) {
+    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (Target) -> (A0, A1, A2, A3, A4) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -905,7 +905,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0 in
@@ -919,7 +919,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSArray) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cba0 in
@@ -933,7 +933,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cbd0 in
@@ -947,7 +947,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cb1 in
@@ -961,7 +961,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cba1 in
@@ -975,7 +975,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cb0, cbd1 in
@@ -989,7 +989,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cba0, cba1 in
@@ -1003,7 +1003,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cba0, cb1 in
@@ -1017,7 +1017,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cba0, cbd1 in
@@ -1031,7 +1031,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cb1 in
@@ -1045,7 +1045,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cba1 in
@@ -1059,7 +1059,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (A0, A1, A2, A3, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let boundFunction = function(target)
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try boundFunction(arg0, arg1, arg2, arg3) { cbd0, cbd1 in

--- a/platforms/apple/Sources/Nimbus/Generated/Callables.generated.swift
+++ b/platforms/apple/Sources/Nimbus/Generated/Callables.generated.swift
@@ -182,3 +182,11 @@ func make_callable<R, A0, A1, A2, A3>(_ function: @escaping ((A0, A1, A2, A3)) t
 func make_callable<R, A0, A1, A2, A3, A4>(_ function: @escaping ((A0, A1, A2, A3, A4)) throws -> R) -> Callable {
     return Callable5(function)
 }
+
+private func decodedArg<A>(value: Any?, type: A.Type) -> A? {
+    if let argString = value as? String,
+        let data = argString.data(using: .utf8) {
+        return decodeJSON(data, destinationType: type)
+    }
+    return nil
+}

--- a/platforms/apple/Sources/Nimbus/Generated/Callables.generated.swift
+++ b/platforms/apple/Sources/Nimbus/Generated/Callables.generated.swift
@@ -40,7 +40,8 @@ struct Callable1<R, A0>: Callable {
         if args.count != 1 {
             throw ParameterError.argumentCount(expected: 1, actual: args.count)
         }
-        if let arg0 = args[0] as? A0 {
+        let decodedArg0 = decodedArg(value: args[0], type: A0.self)
+        if let arg0 = decodedArg0 ?? args[0] as? A0 {
             return try function(arg0)
         }
         throw ParameterError.conversion
@@ -61,8 +62,10 @@ struct Callable2<R, A0, A1>: Callable {
         if args.count != 2 {
             throw ParameterError.argumentCount(expected: 2, actual: args.count)
         }
-        if let arg0 = args[0] as? A0,
-            let arg1 = args[1] as? A1 {
+        let decodedArg0 = decodedArg(value: args[0], type: A0.self)
+        let decodedArg1 = decodedArg(value: args[1], type: A1.self)
+        if let arg0 = decodedArg0 ?? args[0] as? A0,
+            let arg1 = decodedArg1 ?? args[1] as? A1 {
             return try function(arg0, arg1)
         }
         throw ParameterError.conversion
@@ -83,9 +86,12 @@ struct Callable3<R, A0, A1, A2>: Callable {
         if args.count != 3 {
             throw ParameterError.argumentCount(expected: 3, actual: args.count)
         }
-        if let arg0 = args[0] as? A0,
-            let arg1 = args[1] as? A1,
-            let arg2 = args[2] as? A2 {
+        let decodedArg0 = decodedArg(value: args[0], type: A0.self)
+        let decodedArg1 = decodedArg(value: args[1], type: A1.self)
+        let decodedArg2 = decodedArg(value: args[2], type: A2.self)
+        if let arg0 = decodedArg0 ?? args[0] as? A0,
+            let arg1 = decodedArg1 ?? args[1] as? A1,
+            let arg2 = decodedArg2 ?? args[2] as? A2 {
             return try function(arg0, arg1, arg2)
         }
         throw ParameterError.conversion
@@ -106,10 +112,14 @@ struct Callable4<R, A0, A1, A2, A3>: Callable {
         if args.count != 4 {
             throw ParameterError.argumentCount(expected: 4, actual: args.count)
         }
-        if let arg0 = args[0] as? A0,
-            let arg1 = args[1] as? A1,
-            let arg2 = args[2] as? A2,
-            let arg3 = args[3] as? A3 {
+        let decodedArg0 = decodedArg(value: args[0], type: A0.self)
+        let decodedArg1 = decodedArg(value: args[1], type: A1.self)
+        let decodedArg2 = decodedArg(value: args[2], type: A2.self)
+        let decodedArg3 = decodedArg(value: args[3], type: A3.self)
+        if let arg0 = decodedArg0 ?? args[0] as? A0,
+            let arg1 = decodedArg1 ?? args[1] as? A1,
+            let arg2 = decodedArg2 ?? args[2] as? A2,
+            let arg3 = decodedArg3 ?? args[3] as? A3 {
             return try function(arg0, arg1, arg2, arg3)
         }
         throw ParameterError.conversion
@@ -130,11 +140,16 @@ struct Callable5<R, A0, A1, A2, A3, A4>: Callable {
         if args.count != 5 {
             throw ParameterError.argumentCount(expected: 5, actual: args.count)
         }
-        if let arg0 = args[0] as? A0,
-            let arg1 = args[1] as? A1,
-            let arg2 = args[2] as? A2,
-            let arg3 = args[3] as? A3,
-            let arg4 = args[4] as? A4 {
+        let decodedArg0 = decodedArg(value: args[0], type: A0.self)
+        let decodedArg1 = decodedArg(value: args[1], type: A1.self)
+        let decodedArg2 = decodedArg(value: args[2], type: A2.self)
+        let decodedArg3 = decodedArg(value: args[3], type: A3.self)
+        let decodedArg4 = decodedArg(value: args[4], type: A4.self)
+        if let arg0 = decodedArg0 ?? args[0] as? A0,
+            let arg1 = decodedArg1 ?? args[1] as? A1,
+            let arg2 = decodedArg2 ?? args[2] as? A2,
+            let arg3 = decodedArg3 ?? args[3] as? A3,
+            let arg4 = decodedArg4 ?? args[4] as? A4 {
             return try function(arg0, arg1, arg2, arg3, arg4)
         }
         throw ParameterError.conversion

--- a/platforms/apple/Sources/Nimbus/Templates/Binders.swifttemplate
+++ b/platforms/apple/Sources/Nimbus/Templates/Binders.swifttemplate
@@ -53,7 +53,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> Void, as name: String) {
+    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> Void, as name: String)<%= getCommaSeparatedString(count: index, formattingPurpose: .forWhereClause) %> {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -62,7 +62,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<R: Encodable, <%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> R, as name: String) {
+    public func bind<R: Encodable, <%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> R, as name: String)<%= getCommaSeparatedString(count: index, formattingPurpose: .forWhereClause) %> {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -71,7 +71,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSArray, as name: String) {
+    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSArray, as name: String)<%= getCommaSeparatedString(count: index, formattingPurpose: .forWhereClause) %> {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -80,7 +80,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSDictionary, as name: String) {
+    public func bind<<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>>(_ function: @escaping (Target) -> (<%= getCommaSeparatedString(count: index, formattingPurpose: .forTemplateDeclaration) %>) throws -> NSDictionary, as name: String)<%= getCommaSeparatedString(count: index, formattingPurpose: .forWhereClause) %> {
         let boundFunction = function(target)
         let callable = make_callable(boundFunction)
         bind(callable, as: name)
@@ -89,7 +89,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0 in
@@ -103,7 +103,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSArray) -> Void) throws -> Void, as name: String) {
+    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSArray) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0 in
@@ -117,7 +117,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
+    public func bind<% if index > 1 { %><<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>><% }%>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (NSDictionary) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0 in
@@ -131,7 +131,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CB1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cb1 in
@@ -145,7 +145,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cba1 in
@@ -159,7 +159,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cb0, cbd1 in
@@ -173,7 +173,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cba1 in
@@ -187,7 +187,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cb1 in
@@ -201,7 +201,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cba0, cbd1 in
@@ -215,7 +215,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cb1 in
@@ -229,7 +229,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cba1 in
@@ -243,7 +243,7 @@ extension NativeBinder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
+    public func bind<<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (Target) -> (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forTemplateDeclaration) %>, <% }%>@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String)<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWhereClause) %><% }%> {
         let boundFunction = function(target)
         let wrappedFunction = { (<% if index > 1 { %><%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forWrappedFunctionClosure) %>, <% }%>callable: Callable) -> Void in
             try boundFunction<% if index > 1 { %>(<%= getCommaSeparatedString(count: index - 1, formattingPurpose: .forBoundFunctionArgs) %>)<% } %> { cbd0, cbd1 in

--- a/platforms/apple/Sources/Nimbus/Templates/Callables.swifttemplate
+++ b/platforms/apple/Sources/Nimbus/Templates/Callables.swifttemplate
@@ -23,9 +23,12 @@ struct Callable<%= index %><R<% if index > 0 { -%>, <%= getCommaSeparatedString(
             throw ParameterError.argumentCount(expected: <%= index %>, actual: args.count)
         }
 <%_     if index > 0 { -%>
-        if let arg0 = args[0] as? A0<%if index > 1 { -%>,<% } else { %> {<% } %>
+<%          for CURR_POSITION in 0..<index { -%>
+        let decodedArg<%=CURR_POSITION%> = decodedArg(value: args[<%=CURR_POSITION%>], type: A<%=CURR_POSITION%>.self)
+<%          } -%>
+        if let arg0 = decodedArg0 ?? args[0] as? A0<%if index > 1 { -%>,<% } else { %> {<% } %>
 <%          for CURR_POSITION in 1..<index { -%>
-            let arg<%= CURR_POSITION %> = args[<%= CURR_POSITION %>] as? A<%= CURR_POSITION %><% if CURR_POSITION == index - 1 { %> {<% } else { %>,<% } %>
+            let arg<%= CURR_POSITION %> = decodedArg<%= CURR_POSITION %> ?? args[<%= CURR_POSITION %>] as? A<%= CURR_POSITION %><% if CURR_POSITION == index - 1 { %> {<% } else { %>,<% } %>
 <%          } -%>
             return try function(<%= getCommaSeparatedString(count: index, formattingPurpose: .forBoundFunctionArgs) %>)
         }

--- a/platforms/apple/Sources/Nimbus/Templates/Callables.swifttemplate
+++ b/platforms/apple/Sources/Nimbus/Templates/Callables.swifttemplate
@@ -44,3 +44,11 @@ func make_callable<R<% if index > 0 { -%>, <%= getCommaSeparatedString(count: in
     return Callable<%=index%>(function)
 }
 <% } -%>
+
+private func decodedArg<A>(value: Any?, type: A.Type) -> A? {
+    if let argString = value as? String,
+        let data = argString.data(using: .utf8) {
+        return decodeJSON(data, destinationType: type)
+    }
+    return nil
+}

--- a/platforms/apple/Sources/Nimbus/Templates/Utils.swift
+++ b/platforms/apple/Sources/Nimbus/Templates/Utils.swift
@@ -18,6 +18,7 @@ enum FormattingPurpose {
     case forMethodArgsAsIntDecl
     case forArgsSum
     case forWhereClause
+    case forMethodArgsAsDecodableStruct
 }
 
 enum FormattingBinaryCallback {
@@ -60,6 +61,9 @@ func getCommaSeparatedString(count: Int, formattingPurpose: FormattingPurpose) -
     case .forWhereClause:
         // example "where A0: Decodable, A1: Decodable ...."
         return " where " + argIndices.map({(element: Int) in String.init("A\(element): Decodable")}).joined(separator: ", ")
+    case .forMethodArgsAsDecodableStruct:
+        // example "arg0: TestableDecodableStruct, arg1: TestableDecodableStruct ..."
+        return argIndices.map({(element: Int) in String.init(format: "arg%d: TestableDecodableStruct", element)}).joined(separator: ", ")
     }
 }
 

--- a/platforms/apple/Sources/Nimbus/Templates/Utils.swift
+++ b/platforms/apple/Sources/Nimbus/Templates/Utils.swift
@@ -17,6 +17,7 @@ enum FormattingPurpose {
     case forBoundFunctionArgs
     case forMethodArgsAsIntDecl
     case forArgsSum
+    case forWhereClause
 }
 
 enum FormattingBinaryCallback {
@@ -56,6 +57,9 @@ func getCommaSeparatedString(count: Int, formattingPurpose: FormattingPurpose) -
     case .forArgsSum:
         // example: "arg0 + arg1 + arg2 + arg3 ...."
         return argIndices.map({(element: Int) in String.init(format: "arg%d", element)}).joined(separator: " + ")
+    case .forWhereClause:
+        // example "where A0: Decodable, A1: Decodable ...."
+        return " where " + argIndices.map({(element: Int) in String.init("A\(element): Decodable")}).joined(separator: ", ")
     }
 }
 

--- a/platforms/apple/Sources/NimbusTests/DecodableUtilsTests.swift
+++ b/platforms/apple/Sources/NimbusTests/DecodableUtilsTests.swift
@@ -1,0 +1,67 @@
+//
+//  DecodableUtilsTests.swift
+//  NimbusTests
+//
+//  Created by Paul Tiarks on 3/2/20.
+//  Copyright © 2020 Salesforce.com, inc. All rights reserved.
+//
+
+import XCTest
+@testable import Nimbus
+
+class DecodableUtilsTests: XCTestCase {
+
+    func testDecodableSucceeds() {
+        guard let data = successJSON.data(using: .utf8) else {
+            XCTFail("couldn't make data from JSON")
+            return
+        }
+        let testValue = decodeJSON(data, destinationType: TestStruct.self)
+        XCTAssertNotNil(testValue)
+    }
+
+    func testNotDecodableFails() {
+        guard let data = successJSON.data(using: .utf8) else {
+            XCTFail("couldn't make data from JSON")
+            return
+        }
+        let testValue = decodeJSON(data, destinationType: FailTestStruct.self)
+        XCTAssertNil(testValue)
+    }
+
+    func testDecodableWithIncompatibleStringFails() {
+        guard let data = failJSON.data(using: .utf8) else {
+            XCTFail("couldn't make data from JSON")
+            return
+        }
+        let testValue = decodeJSON(data, destinationType: TestStruct.self)
+        XCTAssertNil(testValue)
+    }
+
+    struct TestStruct: Decodable {
+        let number: Int
+        let name: String
+        let list: [String]
+    }
+
+    struct FailTestStruct {
+        let number: Int
+        let name: String
+        let list: [String]
+    }
+
+    let successJSON = """
+    {
+        "number": 42,
+        "name": "TheName",
+        "list": ["One", "Two", "Three"]
+    }
+    """
+
+    let failJSON = """
+    {
+        "blah": "blah"
+    }
+    """
+
+}

--- a/platforms/apple/Sources/NimbusTests/Generated/CallableTests.generated.swift
+++ b/platforms/apple/Sources/NimbusTests/Generated/CallableTests.generated.swift
@@ -201,7 +201,7 @@ class Testable {
     static let decodableJSON = """
         {
             "name": "TheName",
-            "number: 42
+            "number": 42
         }
     """
 

--- a/platforms/apple/Sources/NimbusTests/Generated/CallableTests.generated.swift
+++ b/platforms/apple/Sources/NimbusTests/Generated/CallableTests.generated.swift
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
+// swiftlint:disable line_length vertical_whitespace
 
 import XCTest
 
@@ -82,6 +83,106 @@ class CallableTests: XCTestCase {
         XCTAssertThrowsError(try callable.call(args: [1, 2, 3, 4, 5, 6]))
     }
 
+    func testNullaryDecodable() {
+        let callable = make_callable(Testable.nullaryDecodable(testable))
+        let result = try? callable.call(args: [])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+
+            XCTAssertEqual(args.count, 0)
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+    func testUnaryDecodable() {
+        let callable = make_callable(Testable.unaryDecodable(testable))
+        let result = try? callable.call(args: [Testable.decodableJSON])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }
+
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+    func testBinaryDecodable() {
+        let callable = make_callable(Testable.binaryDecodable(testable))
+        let result = try? callable.call(args: [Testable.decodableJSON, Testable.decodableJSON])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }
+
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+    func testTernaryDecodable() {
+        let callable = make_callable(Testable.ternaryDecodable(testable))
+        let result = try? callable.call(args: [Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }
+
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+    func testQuaternaryDecodable() {
+        let callable = make_callable(Testable.quaternaryDecodable(testable))
+        let result = try? callable.call(args: [Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }
+
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+    func testQuinaryDecodable() {
+        let callable = make_callable(Testable.quinaryDecodable(testable))
+        let result = try? callable.call(args: [Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON, Testable.decodableJSON])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }
+
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+
     func testCallbackable() {
         let callable = make_callable(Testable.callbackable(testable))
         let expect = expectation(description: "called callback")
@@ -96,6 +197,19 @@ class CallableTests: XCTestCase {
 }
 
 class Testable {
+
+    static let decodableJSON = """
+        {
+            "name": "TheName",
+            "number: 42
+        }
+    """
+
+    struct TestableDecodableStruct: Decodable {
+        let name: String
+        let number: Int
+    }
+
     private(set) var called = false
 
     func nullary() -> Int {
@@ -127,6 +241,38 @@ class Testable {
         called = true
         return 5
     }
+
+
+    func nullaryDecodable() -> [TestableDecodableStruct] {
+        called = true
+        return []
+    }
+
+    func unaryDecodable(arg0: TestableDecodableStruct) -> [TestableDecodableStruct] {
+        called = true
+        return [arg0]
+    }
+
+    func binaryDecodable(arg0: TestableDecodableStruct, arg1: TestableDecodableStruct) -> [TestableDecodableStruct] {
+        called = true
+        return [arg0, arg1]
+    }
+
+    func ternaryDecodable(arg0: TestableDecodableStruct, arg1: TestableDecodableStruct, arg2: TestableDecodableStruct) -> [TestableDecodableStruct] {
+        called = true
+        return [arg0, arg1, arg2]
+    }
+
+    func quaternaryDecodable(arg0: TestableDecodableStruct, arg1: TestableDecodableStruct, arg2: TestableDecodableStruct, arg3: TestableDecodableStruct) -> [TestableDecodableStruct] {
+        called = true
+        return [arg0, arg1, arg2, arg3]
+    }
+
+    func quinaryDecodable(arg0: TestableDecodableStruct, arg1: TestableDecodableStruct, arg2: TestableDecodableStruct, arg3: TestableDecodableStruct, arg4: TestableDecodableStruct) -> [TestableDecodableStruct] {
+        called = true
+        return [arg0, arg1, arg2, arg3, arg4]
+    }
+
 
     func callbackable(arg0: Int, arg1: (Int) -> Void) {
         arg1(arg0)

--- a/platforms/apple/Sources/NimbusTests/Templates/CallableTests.swifttemplate
+++ b/platforms/apple/Sources/NimbusTests/Templates/CallableTests.swifttemplate
@@ -69,7 +69,7 @@ class Testable {
     static let decodableJSON = """
         {
             "name": "TheName",
-            "number: 42
+            "number": 42
         }
     """
 

--- a/platforms/apple/Sources/NimbusTests/Templates/CallableTests.swifttemplate
+++ b/platforms/apple/Sources/NimbusTests/Templates/CallableTests.swifttemplate
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
+// swiftlint:disable line_length vertical_whitespace
 
 import XCTest
 
@@ -28,6 +29,28 @@ class CallableTests: XCTestCase {
     }
 <%_  } -%>
 
+<%_  for (index, arity) in arities.enumerated() { -%>
+    func test<%= arity.name.capitalizingFirstLetter() %>Decodable() {
+        let callable = make_callable(Testable.<%= arity.name %>Decodable(testable))
+        let result = try? callable.call(args: [<%_ if index > 0 { -%><%= Array(1...index).map({(element: Int) in String("Testable.decodableJSON")}).joined(separator: ", ") -%><% } _%>])
+        let arrayResult = result as? [Testable.TestableDecodableStruct]
+        XCTAssertNotNil(arrayResult)
+        XCTAssertTrue(testable.called)
+        if let args = arrayResult {
+            <%_ if index > 0 { -%>
+            for arg in args {
+                XCTAssertEqual(arg.name, "TheName")
+                XCTAssertEqual(arg.number, 42)
+            }<% } _%>
+            <%_ if index == 0 { -%>
+            XCTAssertEqual(args.count, 0)<% } _%>
+        } else {
+            XCTFail("result wasn't an array")
+        }
+    }
+
+<%_  } -%>
+
     func testCallbackable() {
         let callable = make_callable(Testable.callbackable(testable))
         let expect = expectation(description: "called callback")
@@ -42,6 +65,19 @@ class CallableTests: XCTestCase {
 }
 
 class Testable {
+
+    static let decodableJSON = """
+        {
+            "name": "TheName",
+            "number: 42
+        }
+    """
+
+    struct TestableDecodableStruct: Decodable {
+        let name: String
+        let number: Int
+    }
+
     private(set) var called = false
 
 <%_  for (index, arity) in arities.enumerated() { -%>
@@ -51,6 +87,15 @@ class Testable {
     }
 
 <%_  } -%>
+
+<%_ for (index, arity) in arities.enumerated() { -%>
+    func <%= arity.name %>Decodable(<% if index > 0 {%><%= getCommaSeparatedString(count: index, formattingPurpose: .forMethodArgsAsDecodableStruct)%><% } %>) -> [TestableDecodableStruct] {
+        called = true
+        return [<% if index > 0 { %><%= getCommaSeparatedString(count: index, formattingPurpose: .forBoundFunctionArgs)%><% } %>]
+    }
+
+<%_ } -%>
+
     func callbackable(arg0: Int, arg1: (Int) -> Void) {
         arg1(arg0)
     }


### PR DESCRIPTION
Also, change how parameters are passed from javascript. Previously on iOS, parameters were passed as objects. They're now passed as json strings which are attempted to be decoded if the parameter type is Decodable.