### PR TITLE
Rename podspec and bump versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: Lint CocoaPod Spec
           working_directory: platforms/apple
-          command: bundle exec pod lib lint --private ../../Nimbus.podspec
+          command: bundle exec pod lib lint --private ../../NimbusBridge.podspec
 
       - run:
           name: Get code coverage

--- a/NimbusBridge.podspec
+++ b/NimbusBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NimbusBridge'
-  s.version          = '0.0.9'
+  s.version          = '0.99.0'
   s.summary          = 'Nimbus is a framework for building cross-platform hybrid applications.'
   s.homepage         = 'https://github.com/salesforce/nimbus'
   s.source           = { :git => 'https://github.com/salesforce/nimbus.git', :tag => s.version.to_s }

--- a/NimbusBridge.podspec
+++ b/NimbusBridge.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name             = 'Nimbus'
+  s.name             = 'NimbusBridge'
   s.version          = '0.0.9'
   s.summary          = 'Nimbus is a framework for building cross-platform hybrid applications.'
   s.homepage         = 'https://github.com/salesforce/nimbus'

--- a/NimbusJS.podspec
+++ b/NimbusJS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name            = 'NimbusJS'
-  s.version         = '0.0.9'
+  s.version         = '0.99.0'
   s.summary         = 'NimbusJS supplies the javascript necessary for the Nimbus framework'
   s.homepage        = 'https://github.com/salesforce/nimbus'
   s.source          = { :http => 'https://github.com/salesforce/nimbus/releases/download/0.0.9/NimbusJS.zip' }

--- a/NimbusJS.podspec
+++ b/NimbusJS.podspec
@@ -12,4 +12,6 @@ Pod::Spec.new do |s|
   s.swift_version   = '4.2'
 
   s.ios.deployment_target = '11.0'
+
+  s.dependency 'NimbusBridge', '= 0.99.0'
 end

--- a/packages/demo-www/package.json
+++ b/packages/demo-www/package.json
@@ -24,6 +24,6 @@
         "typescript": "^3.5.2"
     },
     "dependencies": {
-        "nimbus-bridge": "^0.2.0"
+        "nimbus-bridge": "^0.99.0"
     }
 }

--- a/packages/nimbus-bridge/package.json
+++ b/packages/nimbus-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nimbus-bridge",
-    "version": "0.2.0",
+    "version": "0.99.0",
     "description": "Nimbus is a bridge for hybrid app development.",
     "license": "BSD-3-Clause",
     "main": "dist/iife/nimbus.js",

--- a/packages/test-www/package.json
+++ b/packages/test-www/package.json
@@ -11,7 +11,7 @@
         "serve": "cross-env rollup -c ./rollup.config.js --watch"
     },
     "dependencies": {
-        "nimbus-bridge": "^0.2.0"
+        "nimbus-bridge": "^0.99.0"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Publishing settings
 GROUP=com.salesforce.nimbus
-VERSION=0.0.9
+VERSION=0.99.0
 
 POM_URL=https://github.com/salesforce/nimbus
 POM_SCM_URL=https://github.com/salesforce/nimbus


### PR DESCRIPTION
This does three things

1. Rename Nimbus.podspec to NimbusBridge.podspec to fix a name collision
2. Unify all platform versions and update to 0.99.0 (as discussed offline with @threeve)
3. Add an explicit dependency between NimbusJS and NimbusBridge to ensure consumers aren't using incompatible versions of nimbus.js

We can likely wait to merge this until we are about to release 0.99.0