### PR TITLE
Bump to 0.99.1, fix source url in NimbusJS.podspec

### DIFF
--- a/NimbusBridge.podspec
+++ b/NimbusBridge.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NimbusBridge'
-  s.version          = '0.99.0'
+  s.version          = '0.99.1'
   s.summary          = 'Nimbus is a framework for building cross-platform hybrid applications.'
   s.homepage         = 'https://github.com/salesforce/nimbus'
   s.source           = { :git => 'https://github.com/salesforce/nimbus.git', :tag => s.version.to_s }

--- a/NimbusJS.podspec
+++ b/NimbusJS.podspec
@@ -1,9 +1,9 @@
 Pod::Spec.new do |s|
   s.name            = 'NimbusJS'
-  s.version         = '0.99.0'
+  s.version         = '0.99.1'
   s.summary         = 'NimbusJS supplies the javascript necessary for the Nimbus framework'
   s.homepage        = 'https://github.com/salesforce/nimbus'
-  s.source          = { :http => 'https://github.com/salesforce/nimbus/releases/download/0.0.9/NimbusJS.zip' }
+  s.source          = { :http => 'https://github.com/salesforce/nimbus/releases/download/' + s.version.to_s + '/NimbusJS.zip' }
   s.author          = { 'Hybrid Platform Team' => 'hybridplatform@salesforce.com' }
   s.license         = 'BSD-3-Clause'
   s.source_files    = '*.swift'
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
 
-  s.dependency 'NimbusBridge', '= 0.99.0'
+  s.dependency 'NimbusBridge', '= 0.99.1'
 end

--- a/packages/demo-www/package.json
+++ b/packages/demo-www/package.json
@@ -24,6 +24,6 @@
         "typescript": "^3.5.2"
     },
     "dependencies": {
-        "nimbus-bridge": "^0.99.0"
+        "nimbus-bridge": "^0.99.1"
     }
 }

--- a/packages/nimbus-bridge/package.json
+++ b/packages/nimbus-bridge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nimbus-bridge",
-    "version": "0.99.0",
+    "version": "0.99.1",
     "description": "Nimbus is a bridge for hybrid app development.",
     "license": "BSD-3-Clause",
     "main": "dist/iife/nimbus.js",

--- a/packages/test-www/package.json
+++ b/packages/test-www/package.json
@@ -11,7 +11,7 @@
         "serve": "cross-env rollup -c ./rollup.config.js --watch"
     },
     "dependencies": {
-        "nimbus-bridge": "^0.99.0"
+        "nimbus-bridge": "^0.99.1"
     },
     "devDependencies": {
         "@types/chai": "^4.1.7",

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Publishing settings
 GROUP=com.salesforce.nimbus
-VERSION=0.99.0
+VERSION=0.99.1
 
 POM_URL=https://github.com/salesforce/nimbus
 POM_SCM_URL=https://github.com/salesforce/nimbus


### PR DESCRIPTION
This fixes a mistake in the source url for NimbusJS in 0.99.0