### PR TITLE
Add `Plugin` protocol with updated bind api

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: Lint CocoaPod Spec
           working_directory: platforms/apple
-          command: bundle exec pod lib lint --private ../../NimbusBridge.podspec
+          command: bundle exec pod lib lint --allow-warnings --private ../../NimbusBridge.podspec
 
       - run:
           name: Get code coverage

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		2922900F241165570014B95A /* InvocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2922900E241165570014B95A /* InvocationTests.swift */; };
 		29245EE2220CE13000F9EEAF /* MochaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29245EE1220CE13000F9EEAF /* MochaTests.swift */; };
 		29245EE6220CE18100F9EEAF /* test-www in Resources */ = {isa = PBXBuildFile; fileRef = 29245EE5220CE18100F9EEAF /* test-www */; };
+		29264F5E24197E4F00D68664 /* Plugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29264F5D24197E4F00D68664 /* Plugin.swift */; };
 		294433472200FA3700E6D084 /* Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294433422200FA3700E6D084 /* Callback.swift */; };
 		294433482200FA3700E6D084 /* WebView+Nimbus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294433432200FA3700E6D084 /* WebView+Nimbus.swift */; };
 		294433492200FA3700E6D084 /* EncodableValue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 294433442200FA3700E6D084 /* EncodableValue.swift */; };
@@ -187,6 +188,7 @@
 		2922900E241165570014B95A /* InvocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationTests.swift; sourceTree = "<group>"; };
 		29245EE1220CE13000F9EEAF /* MochaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MochaTests.swift; sourceTree = "<group>"; };
 		29245EE5220CE18100F9EEAF /* test-www */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "test-www"; path = "../../../../packages/test-www/dist/test-www"; sourceTree = "<group>"; };
+		29264F5D24197E4F00D68664 /* Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plugin.swift; sourceTree = "<group>"; };
 		294433422200FA3700E6D084 /* Callback.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Callback.swift; sourceTree = "<group>"; };
 		294433432200FA3700E6D084 /* WebView+Nimbus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WebView+Nimbus.swift"; sourceTree = "<group>"; };
 		294433442200FA3700E6D084 /* EncodableValue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EncodableValue.swift; sourceTree = "<group>"; };
@@ -381,13 +383,14 @@
 				294433452200FA3700E6D084 /* Callable.swift */,
 				294433422200FA3700E6D084 /* Callback.swift */,
 				294433462200FA3700E6D084 /* Connection.swift */,
+				CC251495240D6764001E8D8C /* DecodableUtils.swift */,
 				294433442200FA3700E6D084 /* EncodableValue.swift */,
 				291A860621E530BC00510832 /* Info.plist */,
 				291A860521E530BC00510832 /* Nimbus.h */,
 				291A85FC21E5302C00510832 /* NimbusBridge.swift */,
 				291A85FD21E5302C00510832 /* NimbusExtension.swift */,
+				29264F5D24197E4F00D68664 /* Plugin.swift */,
 				294433432200FA3700E6D084 /* WebView+Nimbus.swift */,
-				CC251495240D6764001E8D8C /* DecodableUtils.swift */,
 			);
 			name = Nimbus;
 			path = Sources/Nimbus;
@@ -1010,6 +1013,7 @@
 				CC251496240D6764001E8D8C /* DecodableUtils.swift in Sources */,
 				294433472200FA3700E6D084 /* Callback.swift in Sources */,
 				2944334A2200FA3700E6D084 /* Callable.swift in Sources */,
+				29264F5E24197E4F00D68664 /* Plugin.swift in Sources */,
 				68FA8B95233DEAF900682431 /* Callables.generated.swift in Sources */,
 				291A861121E531B200510832 /* NimbusExtension.swift in Sources */,
 			);

--- a/platforms/apple/Sources/Nimbus/Extensions/DeviceExtension.swift
+++ b/platforms/apple/Sources/Nimbus/Extensions/DeviceExtension.swift
@@ -53,7 +53,7 @@ struct DeviceInfo: Codable {
     #endif
 }
 
-public class DeviceExtension {
+public class DeviceInfoPlugin {
     public init() {}
 
     func getDeviceInfo() -> DeviceInfo {
@@ -63,9 +63,9 @@ public class DeviceExtension {
     let deviceInfo = DeviceInfo()
 }
 
-extension DeviceExtension: NimbusExtension {
-    public func bindToWebView(webView: WKWebView) {
+extension DeviceInfoPlugin: Plugin {
+    public func bind(to webView: WKWebView, bridge: NimbusBridge) {
         let connection = webView.addConnection(to: self, as: "DeviceExtension")
-        connection.bind(DeviceExtension.getDeviceInfo, as: "getDeviceInfo")
+        connection.bind(DeviceInfoPlugin.getDeviceInfo, as: "getDeviceInfo")
     }
 }

--- a/platforms/apple/Sources/Nimbus/NimbusBridge.swift
+++ b/platforms/apple/Sources/Nimbus/NimbusBridge.swift
@@ -9,15 +9,21 @@ import Foundation
 import WebKit
 
 public class NimbusBridge: NSObject {
-    @objc public func addExtension(ext: NimbusExtension) {
-        extensions.append(ext)
+    @available(*, deprecated, message: "Use `NimbusBridge.addPlugin()` instead")
+    public func addExtension(ext: NimbusExtension) {
+        plugins.append(ext)
     }
 
+    @available(*, deprecated, message: "Use `NimbusBridge.addPlugin()` instead")
     public func addExtension<T: NimbusExtension>(_ ext: T) {
-        extensions.append(ext)
+        plugins.append(ext)
     }
 
-    @objc public func attach(to webView: WKWebView) {
+    public func addPlugin<T: Plugin>(_ plugin: T) {
+        plugins.append(plugin)
+    }
+
+    public func attach(to webView: WKWebView) {
         guard self.webView == nil else {
             return
         }
@@ -30,8 +36,8 @@ public class NimbusBridge: NSObject {
             configuration.preferences.setValue(true, forKey: "developerExtrasEnabled")
         #endif
 
-        for ext in extensions {
-            ext.bindToWebView(webView: webView)
+        for plugin in plugins {
+            plugin.bind(to: webView, bridge: self)
         }
     }
 
@@ -133,7 +139,7 @@ public class NimbusBridge: NSObject {
         invoke(identifierSegments, with: args, callback: callback)
     }
 
-    var extensions: [NimbusExtension] = []
+    var plugins: [Plugin] = []
     private let promisesQueue = DispatchQueue(label: "Nimbus.promisesQueue")
     typealias PromiseCallback = (Error?, Any?) -> Void
     private var promises: [String: PromiseCallback] = [:]

--- a/platforms/apple/Sources/Nimbus/NimbusExtension.swift
+++ b/platforms/apple/Sources/Nimbus/NimbusExtension.swift
@@ -7,6 +7,7 @@
 
 import WebKit
 
-@objc public protocol NimbusExtension {
+@available(*, deprecated, message: "Use the `Plugin` protocol instead. `NimbusExtension` will be removed in the future")
+public protocol NimbusExtension: Plugin {
     func bindToWebView(webView: WKWebView)
 }

--- a/platforms/apple/Sources/Nimbus/Plugin.swift
+++ b/platforms/apple/Sources/Nimbus/Plugin.swift
@@ -1,0 +1,29 @@
+//
+// Copyright (c) 2019, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+import WebKit
+
+/**
+ A plugin integrates native capabilities into a JavaScript runtime environment.
+ */
+public protocol Plugin: class {
+
+    /**
+     Bind this plugin to the specified web view and Nimbus bridge.
+
+     Plugins can implement the bind method to add connections and expose methods
+     to the web view, make additional configuration changes to the web view, or
+     call additional methods on the nimbus bridge prior to the web app being loaded.
+     */
+    func bind(to webView: WKWebView, bridge: NimbusBridge)
+}
+
+extension Plugin where Self: NimbusExtension {
+    public func bind(to webView: WKWebView, bridge: NimbusBridge) {
+        bindToWebView(webView: webView)
+    }
+}

--- a/platforms/apple/Sources/NimbusMobileApp/ViewController.swift
+++ b/platforms/apple/Sources/NimbusMobileApp/ViewController.swift
@@ -14,8 +14,7 @@ class ViewController: UIViewController {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         title = "Nimbus"
-
-        bridge.addExtension(DeviceExtension())
+        bridge.addPlugin(DeviceInfoPlugin())
     }
 
     override func loadView() {

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -77,7 +77,7 @@ class MochaTests: XCTestCase, WKNavigationDelegate {
         connection.bind(MochaTestBridge.sendMessage, as: "sendMessage")
         connection.bind(MochaTestBridge.onTestFail, as: "onTestFail")
         let callbackTestExtension = CallbackTestExtension()
-        callbackTestExtension.bindToWebView(webView: webView)
+        callbackTestExtension.bind(to: webView, bridge: NimbusBridge())
 
         loadWebViewAndWait()
 
@@ -120,8 +120,8 @@ public class CallbackTestExtension {
     }
 }
 
-extension CallbackTestExtension: NimbusExtension {
-    public func bindToWebView(webView: WKWebView) {
+extension CallbackTestExtension: Plugin {
+    public func bind(to webView: WKWebView, bridge: NimbusBridge) {
         let connection = webView.addConnection(to: self, as: "callbackTestExtension")
         connection.bind(CallbackTestExtension.callbackWithSingleParam, as: "callbackWithSingleParam")
         connection.bind(CallbackTestExtension.callbackWithTwoParams, as: "callbackWithTwoParams")


### PR DESCRIPTION
This protocol will replace `NimbusExtension` in v1.0. It takes an
additional parameter which is the bridge the plugin is being bound by.
There is a default implementation that calls through to the old method
for now, but this default implementation and the old protocol will be
removed in the near future.