### PR TITLE
Unify version numbers across platforms

### DIFF
--- a/NimbusBridge.podspec
+++ b/NimbusBridge.podspec
@@ -1,6 +1,15 @@
+require 'json'
+
+root = __dir__
+package_version = lambda do |filename = 'lerna.json'|
+  path = File.join(root, filename)
+  JSON.load(File.read(path))['version']
+end
+
+version = package_version.call
 Pod::Spec.new do |s|
   s.name             = 'NimbusBridge'
-  s.version          = '0.99.1'
+  s.version          = version
   s.summary          = 'Nimbus is a framework for building cross-platform hybrid applications.'
   s.homepage         = 'https://github.com/salesforce/nimbus'
   s.source           = { :git => 'https://github.com/salesforce/nimbus.git', :tag => s.version.to_s }

--- a/NimbusJS.podspec
+++ b/NimbusJS.podspec
@@ -1,6 +1,15 @@
+require 'json'
+
+root = __dir__
+package_version = lambda do |filename = 'lerna.json'|
+  path = File.join(root, filename)
+  JSON.load(File.read(path))['version']
+end
+
+version = package_version.call
 Pod::Spec.new do |s|
   s.name            = 'NimbusJS'
-  s.version         = '0.99.1'
+  s.version         = version
   s.summary         = 'NimbusJS supplies the javascript necessary for the Nimbus framework'
   s.homepage        = 'https://github.com/salesforce/nimbus'
   s.source          = { :http => 'https://github.com/salesforce/nimbus/releases/download/' + s.version.to_s + '/NimbusJS.zip' }
@@ -13,5 +22,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
 
-  s.dependency 'NimbusBridge', '= 0.99.1'
+  s.dependency 'NimbusBridge', '= ' + version
 end

--- a/lerna.json
+++ b/lerna.json
@@ -1,4 +1,7 @@
 {
-  "packages": ["packages/*", "docs"],
-  "version": "0.2.0"
+  "packages": [
+    "packages/*",
+    "docs"
+  ],
+  "version": "0.99.1"
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "scripts": {
         "prepare": "lerna bootstrap",
-        "bump": "lerna version --no-git-tag-version --no-push; ./sync-apple-versions.sh",
+        "bump": "lerna version --no-git-tag-version --no-push",
         "lint": "lerna run lint",
         "serve:demo": "lerna run serve --scope demo-www --stream",
         "clean": "lerna run clean"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     },
     "scripts": {
         "prepare": "lerna bootstrap",
+        "bump": "lerna version --no-git-tag-version --no-push",
         "lint": "lerna run lint",
         "serve:demo": "lerna run serve --scope demo-www --stream",
         "clean": "lerna run clean"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     },
     "scripts": {
         "prepare": "lerna bootstrap",
-        "bump": "lerna version --no-git-tag-version --no-push",
+        "bump": "lerna version --no-git-tag-version --no-push; ./sync-apple-versions.sh",
         "lint": "lerna run lint",
         "serve:demo": "lerna run serve --scope demo-www --stream",
         "clean": "lerna run clean"

--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -4,7 +4,8 @@ org.gradle.jvmargs=-Xmx1536m
 
 # Publishing settings
 GROUP=com.salesforce.nimbus
-VERSION=0.99.1
+# This will get overridden by each modules build
+VERSION=0.0.1
 
 POM_URL=https://github.com/salesforce/nimbus
 POM_SCM_URL=https://github.com/salesforce/nimbus

--- a/platforms/android/nimbus-annotations/build.gradle
+++ b/platforms/android/nimbus-annotations/build.gradle
@@ -11,6 +11,12 @@ targetCompatibility = "7"
 
 buildscript {
     ext.kotlin_version = '1.3.50'
+
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
+    project.version = parsedVersion.version.toString()
+    logger.warn("nimbus-annotations version: " + project.version.toString())
+
     repositories {
         mavenCentral()
     }

--- a/platforms/android/nimbus-annotations/build.gradle
+++ b/platforms/android/nimbus-annotations/build.gradle
@@ -15,7 +15,6 @@ buildscript {
     def versionFile = file('../../../lerna.json')
     def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
     project.version = parsedVersion.version.toString()
-    logger.warn("nimbus-annotations version: " + project.version.toString())
 
     repositories {
         mavenCentral()

--- a/platforms/android/nimbus-compiler/build.gradle
+++ b/platforms/android/nimbus-compiler/build.gradle
@@ -13,6 +13,12 @@ targetCompatibility = "7"
 
 buildscript {
     ext.kotlin_version = '1.3.50'
+
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
+    project.version = parsedVersion.version.toString()
+    logger.warn("nimbus-compiler version: " + project.version.toString())
+
     repositories {
         mavenCentral()
     }

--- a/platforms/android/nimbus-compiler/build.gradle
+++ b/platforms/android/nimbus-compiler/build.gradle
@@ -17,7 +17,6 @@ buildscript {
     def versionFile = file('../../../lerna.json')
     def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
     project.version = parsedVersion.version.toString()
-    logger.warn("nimbus-compiler version: " + project.version.toString())
 
     repositories {
         mavenCentral()

--- a/platforms/android/nimbus/build.gradle
+++ b/platforms/android/nimbus/build.gradle
@@ -7,6 +7,11 @@ apply plugin: 'jacoco-android'
 android {
     compileSdkVersion 29
 
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
+    project.version = parsedVersion.version.toString()
+    logger.warn("nimbus version: " + project.version.toString())
+
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 29

--- a/platforms/android/nimbus/build.gradle
+++ b/platforms/android/nimbus/build.gradle
@@ -10,7 +10,6 @@ android {
     def versionFile = file('../../../lerna.json')
     def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
     project.version = parsedVersion.version.toString()
-    logger.warn("nimbus version: " + project.version.toString())
 
     defaultConfig {
         minSdkVersion 21

--- a/platforms/android/nimbusjs/build.gradle
+++ b/platforms/android/nimbusjs/build.gradle
@@ -5,6 +5,10 @@ android {
     compileSdkVersion 29
     buildToolsVersion "29.0.2"
 
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
+    project.version = parsedVersion.version.toString()
+    logger.warn("nimbusjs version: " + project.version.toString())
 
     defaultConfig {
         minSdkVersion 19

--- a/platforms/android/nimbusjs/build.gradle
+++ b/platforms/android/nimbusjs/build.gradle
@@ -8,7 +8,6 @@ android {
     def versionFile = file('../../../lerna.json')
     def parsedVersion = new groovy.json.JsonSlurper().parseText(versionFile.text)
     project.version = parsedVersion.version.toString()
-    logger.warn("nimbusjs version: " + project.version.toString())
 
     defaultConfig {
         minSdkVersion 19

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -587,6 +587,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 291A860C21E530BC00510832 /* Build configuration list for PBXNativeTarget "Nimbus" */;
 			buildPhases = (
+				CC13116724256DBA002D698D /* Set Version */,
 				29CD07F62214BC9D007D3AF3 /* Run SwiftLint */,
 				291A85FE21E530BC00510832 /* Headers */,
 				291A85FF21E530BC00510832 /* Sources */,
@@ -698,6 +699,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = CC97225423E4834400F899E7 /* Build configuration list for PBXNativeTarget "NimbusJS" */;
 			buildPhases = (
+				CC131168242571DE002D698D /* Set Version */,
 				CC97223823E4834400F899E7 /* Headers */,
 				CC97223923E4834400F899E7 /* Sources */,
 				CC97223A23E4834400F899E7 /* Frameworks */,
@@ -983,6 +985,42 @@
 			shellPath = "/bin/bash -l";
 			shellScript = "pushd ${SRCROOT}/../..\nnpm install\n";
 			showEnvVarsInLog = 0;
+		};
+		CC13116724256DBA002D698D /* Set Version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Set Version";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
+		};
+		CC131168242571DE002D698D /* Set Version */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Set Version";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -1002,7 +1002,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
 		};
 		CC131168242571DE002D698D /* Set Version */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1020,7 +1020,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/sync-apple-versions.sh
+++ b/sync-apple-versions.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+FULL_VERSION="$(grep -Ei '\"version\": \"([.0-9]+)\"' lerna.json)"
+VERSION="$(echo ${FULL_VERSION}\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')"
+
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" platforms/apple/Sources/Nimbus/Info.plist
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" platforms/apple/Sources/NimbusJS/Info.plist

--- a/sync-apple-versions.sh
+++ b/sync-apple-versions.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-FULL_VERSION="$(grep -Ei '\"version\": \"([.0-9]+)\"' lerna.json)"
-VERSION="$(echo ${FULL_VERSION}\ | grep -E -o '[0-9]+.[0-9]+.[0-9]')"
-
-/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" platforms/apple/Sources/Nimbus/Info.plist
-/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${VERSION}" platforms/apple/Sources/NimbusJS/Info.plist


### PR DESCRIPTION
This change rallies each platforms version around a single version number, ensuring that version numbers move forward uniformly and with minimal effort.

The single source of version number will be the `lerna.json` file in the project root. We are already using lerna to unify the version of the typescript packages, so this seems like a reasonable resource to make as the source of truth.

When a new version needs to be created, we can run the `bump` task which will move the version number forward.

Android and iOS will then refer to the `lerna.json` file in their respective build scripts and podspecs.

Absent from this PR is any sort of CI check to make sure that version numbers are, in fact, in sync and nothing has broken with the various implementations. Would be interested in feedback on whether that kind of check would be necessary.