### PR TITLE
Using Bridge.invoke() and removed WebView.callJavascript() extension

### DIFF
--- a/platforms/android/nimbus-bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/MochaTests.kt
+++ b/platforms/android/nimbus-bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/MochaTests.kt
@@ -16,6 +16,7 @@ import com.salesforce.nimbus.BoundMethod
 import com.salesforce.nimbus.JSONSerializable
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
+import com.salesforce.nimbus.toJSONSerializable
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/platforms/android/nimbus-bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
+++ b/platforms/android/nimbus-bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
@@ -9,57 +9,6 @@ package com.salesforce.nimbus.bridge.webview
 
 import android.webkit.WebView
 import com.salesforce.nimbus.JSONSerializable
-import org.json.JSONArray
-import org.json.JSONObject
-
-/**
- * Asynchronously call a Javascript function. This method must be called on UI thread.
- *
- * @param name Name of a function or a method on an object to call.  Fully qualify this name
- *             by separating with a dot and do not need to add parenthesis. The function
- *             to be performed in Javascript must already be defined and exist there.  Do not
- *             pass a snippet of code to evaluate.
- * @param args Array of argument objects.  They will be Javascript stringified in this
- *             method and be passed the function as specified in 'name'. If you are calling a
- *             Javascript function that does not take any parameters pass empty array instead of nil.
- * @param completionHandler A block to invoke when script evaluation completes or fails. You do not
- *                          have to pass a closure if you are not interested in getting the callback.
- */
-@Deprecated("Call `NimbusBridge.invoke` instead. This method will be removed prior to v1.0.0")
-fun WebView.callJavascript(name: String, args: Array<JSONSerializable?> = emptyArray(), completionHandler: ((result: Any?) -> Unit)? = null) {
-    val jsonArray = JSONArray()
-    args.forEach { jsonSerializable ->
-        val asPrimitive = jsonSerializable as? PrimitiveJSONSerializable
-        if (asPrimitive != null) {
-            jsonArray.put(asPrimitive.value)
-        } else {
-            jsonArray.put(if (jsonSerializable == null) JSONObject.NULL
-                    else JSONObject(jsonSerializable.stringify()))
-        }
-    }
-
-    val jsonString = jsonArray.toString()
-    val scriptTemplate = """
-        try {
-            var jsonArr = $jsonString;
-            if (jsonArr && jsonArr.length > 0) {
-                $name(...jsonArr);
-            } else {
-                $name();
-            }
-        } catch(e) {
-            console.log('Error parsing JSON during a call to callJavascript:' + e.toString());
-        }
-    """.trimIndent()
-
-    handler.post {
-        evaluateJavascript(scriptTemplate) { value ->
-            completionHandler?.let {
-                completionHandler(value)
-            }
-        }
-    }
-}
 
 /**
  * Asynchronously broadcast a message to subscribers listening on Javascript side.  Message can be

--- a/platforms/android/nimbus-bridge-webview/src/test/java/com/salesforce/nimbus/bridge/webview/WebViewBridgeTest.kt
+++ b/platforms/android/nimbus-bridge-webview/src/test/java/com/salesforce/nimbus/bridge/webview/WebViewBridgeTest.kt
@@ -65,8 +65,8 @@ class WebViewBridgeTest {
     @Test
     fun attachBindsToBinders() {
         webViewBridge.attach(mockWebView)
-        verify { mockPlugin1Binder.bind(mockWebView) }
-        verify { mockPlugin2Binder.bind(mockWebView) }
+        verify { mockPlugin1Binder.bind(webViewBridge) }
+        verify { mockPlugin2Binder.bind(webViewBridge) }
     }
 
     @Test

--- a/platforms/android/nimbus-core/build.gradle
+++ b/platforms/android/nimbus-core/build.gradle
@@ -1,40 +1,53 @@
-apply plugin: 'java-library'
-apply plugin: 'kotlin'
+import groovy.json.JsonSlurper
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka'
+
+android {
+    compileSdkVersion 29
+
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new JsonSlurper().parseText(versionFile.text)
+    project.version = parsedVersion.version.toString()
+
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 29
+        versionCode 1
+        versionName version
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            testCoverageEnabled false
+        }
+        debug {
+            testCoverageEnabled true
+        }
+    }
+
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
+}
 
 dependencies {
     api project(":nimbus-annotations")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    testImplementation 'io.kotlintest:kotlintest-runner-junit4:3.1.5'
+    testImplementation 'org.json:json:20190722'
 }
 
-repositories {
-    mavenCentral()
-}
-
-compileKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
-compileTestKotlin {
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-}
-
-task sourcesJar(type: Jar, dependsOn:classes) {
+task sourcesJar(type: Jar) {
     archiveClassifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn:javadoc) {
-    archiveClassifier = 'javadoc'
-    from javadoc.destinationDir
+    from android.sourceSets.main.java.srcDirs
 }
 
 artifacts {
-    archives javadocJar
     archives sourcesJar
 }
 

--- a/platforms/android/nimbus-core/src/main/AndroidManifest.xml
+++ b/platforms/android/nimbus-core/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.salesforce.nimbus" />

--- a/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/Binder.kt
+++ b/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/Binder.kt
@@ -24,9 +24,9 @@ interface Binder<JavascriptEngine> {
     fun getPluginName(): String
 
     /**
-     * Binds to the [JavascriptEngine].
+     * Binds to the [Runtime].
      */
-    fun bind(javascriptEngine: JavascriptEngine)
+    fun bind(runtime: Runtime<JavascriptEngine>)
 
     /**
      * Unbinds from the [JavascriptEngine].

--- a/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/PrimitiveExtensions.kt
+++ b/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/PrimitiveExtensions.kt
@@ -5,15 +5,14 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-package com.salesforce.nimbus.bridge.webview
+package com.salesforce.nimbus
 
-import com.salesforce.nimbus.JSONSerializable
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.HashMap
 
 // Making this internal so it's not a footgun to consumers
-internal class PrimitiveJSONSerializable(val value: Any) :
+class PrimitiveJSONSerializable(val value: Any) :
     JSONSerializable {
     private val stringifiedValue: String
 

--- a/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/Runtime.kt
+++ b/platforms/android/nimbus-core/src/main/java/com/salesforce/nimbus/Runtime.kt
@@ -16,6 +16,6 @@ interface Runtime<JavascriptEngine> {
     fun invoke(
         functionName: String,
         args: Array<JSONSerializable?> = emptyArray(),
-        callback: Promise
+        callback: ((String?, Any?) -> Unit)?
     )
 }

--- a/platforms/android/nimbus-core/src/test/java/com/salesforce/nimbus/PrimitiveExtensionsTests.kt
+++ b/platforms/android/nimbus-core/src/test/java/com/salesforce/nimbus/PrimitiveExtensionsTests.kt
@@ -5,7 +5,7 @@
 // For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-package com.salesforce.nimbus.bridge.webview
+package com.salesforce.nimbus
 
 import io.kotlintest.properties.Gen
 import io.kotlintest.properties.forAll


### PR DESCRIPTION
### Changes

- Moved `PrimitiveExtensions` to `nimbus-core` module
- Made `nimbus-core` module an android library so it can access `JSONObject`
- Updated `WebViewBinderGenerator` to call `Runtime.invoke()` function instead of the `WebView.callJavascript()` extension function
- Removed (Deprecated) `WebView.callJavascript()` extension function