### PR TITLE
Remove support for `NSArray` and `NSDictionary` in binders

### DIFF
--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -34,22 +34,6 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind(_ function: @escaping () throws -> NSArray, as name: String) {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind(_ function: @escaping () throws -> NSDictionary, as name: String) {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0>(_ function: @escaping (A0) throws -> Void, as name: String) where A0: Decodable {
         let callable = make_callable(function)
         bind(callable, as: name)
@@ -59,22 +43,6 @@ extension Binder {
      Bind the specified function to this connection.
      */
     public func bind<R: Encodable, A0>(_ function: @escaping (A0) throws -> R, as name: String) where A0: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0>(_ function: @escaping (A0) throws -> NSArray, as name: String) where A0: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0>(_ function: @escaping (A0) throws -> NSDictionary, as name: String) where A0: Decodable {
         let callable = make_callable(function)
         bind(callable, as: name)
     }
@@ -95,140 +63,10 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind(_ function: @escaping (@escaping (NSArray) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cba0 in
-                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind(_ function: @escaping (@escaping (NSDictionary) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cbd0 in
-                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<CB0: Encodable, CB1: Encodable>(_ function: @escaping (@escaping (CB0, CB1) -> Void) throws -> Void, as name: String) {
         let wrappedFunction = { (callable: Callable) -> Void in
             try function { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CB0: Encodable, CBA1: NSArray>(_ function: @escaping (@escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cb0, cba1 in
-                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (@escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cb0, cbd1 in
-                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (@escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cba0, cba1 in
-                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBA0: NSArray, CB1: Encodable>(_ function: @escaping (@escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cba0, cb1 in
-                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (@escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cba0, cbd1 in
-                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (@escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cbd0, cb1 in
-                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (@escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cbd0, cba1 in
-                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (@escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) {
-        let wrappedFunction = { (callable: Callable) -> Void in
-            try function { cbd0, cbd1 in
-                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -254,22 +92,6 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (A0, A1) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1>(_ function: @escaping (A0, A1) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, CB0: Encodable>(_ function: @escaping (A0, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try function(arg0) { cb0 in
@@ -283,140 +105,10 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0>(_ function: @escaping (A0, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cba0 in
-                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0>(_ function: @escaping (A0, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cbd0 in
-                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, CB0: Encodable, CB1: Encodable>(_ function: @escaping (A0, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
         let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
             try function(arg0) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (A0, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cb0, cba1 in
-                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (A0, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cb0, cbd1 in
-                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (A0, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cba0, cba1 in
-                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (A0, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cba0, cb1 in
-                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (A0, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cba0, cbd1 in
-                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (A0, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cbd0, cb1 in
-                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (A0, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cbd0, cba1 in
-                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (A0, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable {
-        let wrappedFunction = { (arg0: A0, callable: Callable) -> Void in
-            try function(arg0) { cbd0, cbd1 in
-                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -442,22 +134,6 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (A0, A1, A2) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2>(_ function: @escaping (A0, A1, A2) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, A1, CB0: Encodable>(_ function: @escaping (A0, A1, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try function(arg0, arg1) { cb0 in
@@ -471,140 +147,10 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1>(_ function: @escaping (A0, A1, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cba0 in
-                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1>(_ function: @escaping (A0, A1, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cbd0 in
-                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, A1, CB0: Encodable, CB1: Encodable>(_ function: @escaping (A0, A1, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
         let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
             try function(arg0, arg1) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (A0, A1, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cb0, cba1 in
-                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (A0, A1, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cb0, cbd1 in
-                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (A0, A1, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cba0, cba1 in
-                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (A0, A1, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cba0, cb1 in
-                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (A0, A1, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cba0, cbd1 in
-                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (A0, A1, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cbd0, cb1 in
-                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (A0, A1, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cbd0, cba1 in
-                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (A0, A1, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, callable: Callable) -> Void in
-            try function(arg0, arg1) { cbd0, cbd1 in
-                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -630,22 +176,6 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (A0, A1, A2, A3) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (A0, A1, A2, A3) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, A1, A2, CB0: Encodable>(_ function: @escaping (A0, A1, A2, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try function(arg0, arg1, arg2) { cb0 in
@@ -659,140 +189,10 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2>(_ function: @escaping (A0, A1, A2, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cba0 in
-                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2>(_ function: @escaping (A0, A1, A2, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cbd0 in
-                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(_ function: @escaping (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
             try function(arg0, arg1, arg2) { cb0, cb1 in
                 _ = try! callable.call(args: [cb0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cb0, cba1 in
-                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cb0, cbd1 in
-                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cba0, cba1 in
-                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (A0, A1, A2, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cba0, cb1 in
-                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cba0, cbd1 in
-                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (A0, A1, A2, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cbd0, cb1 in
-                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cbd0, cba1 in
-                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2) { cbd0, cbd1 in
-                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -818,52 +218,10 @@ extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (A0, A1, A2, A3, A4) throws -> NSArray, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, A4>(_ function: @escaping (A0, A1, A2, A3, A4) throws -> NSDictionary, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable, A4: Decodable {
-        let callable = make_callable(function)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     public func bind<A0, A1, A2, A3, CB0: Encodable>(_ function: @escaping (A0, A1, A2, A3, @escaping (CB0) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
         let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
             try function(arg0, arg1, arg2, arg3) { cb0 in
                 _ = try! callable.call(args: [cb0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (A0, A1, A2, A3, @escaping (NSArray) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cba0 in
-                _ = try! callable.call(args: [cba0]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3>(_ function: @escaping (A0, A1, A2, A3, @escaping (NSDictionary) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cbd0 in
-                _ = try! callable.call(args: [cbd0]) // swiftlint:disable:this force_try
             }
         }
         let callable = make_callable(wrappedFunction)
@@ -883,107 +241,4 @@ extension Binder {
         bind(callable, as: name)
     }
 
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CB0: Encodable, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, A3, @escaping (CB0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cb0, cba1 in
-                _ = try! callable.call(args: [cb0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CB0: Encodable, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, A3, @escaping (CB0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cb0, cbd1 in
-                _ = try! callable.call(args: [cb0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBA0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cba0, cba1 in
-                _ = try! callable.call(args: [cba0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CB1: Encodable>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBA0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cba0, cb1 in
-                _ = try! callable.call(args: [cba0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBA0: NSArray, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBA0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cba0, cbd1 in
-                _ = try! callable.call(args: [cba0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CB1: Encodable>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBD0, CB1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cbd0, cb1 in
-                _ = try! callable.call(args: [cbd0, cb1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBA1: NSArray>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBD0, CBA1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cbd0, cba1 in
-                _ = try! callable.call(args: [cbd0, cba1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
-    public func bind<A0, A1, A2, A3, CBD0: NSDictionary, CBD1: NSDictionary>(_ function: @escaping (A0, A1, A2, A3, @escaping (CBD0, CBD1) -> Void) throws -> Void, as name: String) where A0: Decodable, A1: Decodable, A2: Decodable, A3: Decodable {
-        let wrappedFunction = { (arg0: A0, arg1: A1, arg2: A2, arg3: A3, callable: Callable) -> Void in
-            try function(arg0, arg1, arg2, arg3) { cbd0, cbd1 in
-                _ = try! callable.call(args: [cbd0, cbd1]) // swiftlint:disable:this force_try
-            }
-        }
-        let callable = make_callable(wrappedFunction)
-        bind(callable, as: name)
-    }
 }

--- a/platforms/apple/Sources/Nimbus/Callback.swift
+++ b/platforms/apple/Sources/Nimbus/Callback.swift
@@ -35,13 +35,9 @@ class Callback: Callable {
                 let jsonData = try jsonEncoder.encode(EncodableValue.value(encodable))
                 let jsonString = String(data: jsonData, encoding: .utf8)!
                 return jsonString
-            } else if arg is NSArray || arg is NSDictionary {
-                let data = try JSONSerialization.data(withJSONObject: arg, options: [])
-                let jsonString = String(data: data, encoding: String.Encoding.utf8)!
-                return jsonString
             } else {
                 // Parameters passed to callback are implied that they
-                // conform to Encodable protocol or be either NSArray or NSDictionary.
+                // conform to Encodable protocol.
                 // If for some reason any elements don't throw parameter error.
                 throw ParameterError.conversion
             }

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -34,22 +34,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(value, .some("value"))
     }
 
-    func testBindNullaryWithNSArrayReturn() {
-        binder.bind(binder.target.nullaryWithNSArrayReturn, as: "")
-        let value = try? binder.callable?.call(args: []) as? NSArray
-        XCTAssert(binder.target.called)
-        let isExpectedType = value is NSArray
-        XCTAssertEqual(isExpectedType, true)
-    }
-
-    func testBindNullaryWithNSDictionaryReturn() {
-        binder.bind(binder.target.nullaryWithNSDictionaryReturn, as: "")
-        let value = try? binder.callable?.call(args: []) as? NSDictionary
-        XCTAssert(binder.target.called)
-        let isExpectedType = value is NSDictionary
-        XCTAssertEqual(isExpectedType, true)
-    }
-
     func testBindNullaryWithReturnThrows() {
         binder.bind(binder.target.nullaryWithReturnThrows, as: "")
         XCTAssertThrowsError(try binder.callable?.call(args: []))
@@ -73,30 +57,6 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(42))
-    }
-
-    func testBindUnaryWithNSArrayReturn() throws {
-        binder.bind(binder.target.unaryWithNSArrayReturn, as: "")
-        let value = try binder.callable?.call(args: [42]) as? NSArray
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value.firstObject as? Int {
-            XCTAssertEqual(result, 42)
-        } else {
-            XCTFail("Value not found")
-        }
-    }
-
-    func testBindUnaryWithNSDictionaryReturn() throws {
-        binder.bind(binder.target.unaryWithNSDictionaryReturn, as: "")
-        let value = try binder.callable?.call(args: [42]) as? NSDictionary
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value["result"] as? Int {
-            XCTAssertEqual(result, 42)
-        } else {
-            XCTFail("Value not found")
-        }
     }
 
     func testBindUnaryWithReturnThrows() throws {
@@ -144,142 +104,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
-    func testBindUnaryWithBinaryPrimitiveNSArrayCallback() {
-        binder.bind(binder.target.unaryWithBinaryPrimitiveNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
-            result = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindUnaryWithBinaryPrimitiveNSDictionaryCallback() {
-        binder.bind(binder.target.unaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
-            result = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindUnaryWithBinaryNSArrayPrimitiveCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSArrayPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
-            resultArray = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(37))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindUnaryWithBinaryNSArrayNSArrayCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSArrayNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray1: NSArray?
-        var resultArray2: NSArray?
-        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
-            resultArray1 = value1
-            resultArray2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray1, ["one", "two", "three"])
-        XCTAssertEqual(resultArray2, ["four", "five", "six"])
-    }
-
-    func testBindUnaryWithBinaryNSArrayNSDictionaryCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSArrayNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray: NSArray?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
-            resultArray = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindUnaryWithBinaryNSDictionaryPrimitiveCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
-            resultDict = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(result, .some(37))
-    }
-
-    func testBindUnaryWithBinaryNSDictionaryNSArrayCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSDictionaryNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict: NSDictionary?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
-            resultDict = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindUnaryWithBinaryNSDictionaryNSDictionaryCallback() {
-        binder.bind(binder.target.unaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict1: NSDictionary?
-        var resultDict2: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
-            resultDict1 = value1
-            resultDict2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
-    }
-
     func testBindUnaryWithBinaryCallbackThrows() {
         binder.bind(binder.target.unaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -308,30 +132,6 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(79))
-    }
-
-    func testBindBinaryWithNSArrayReturn() throws {
-        binder.bind(binder.target.binaryWithNSArrayReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37]) as? NSArray
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value.firstObject as? Int {
-            XCTAssertEqual(result, 79)
-        } else {
-            XCTFail("Value not found")
-        }
-    }
-
-    func testBindBinaryWithNSDictionaryReturn() throws {
-        binder.bind(binder.target.binaryWithNSDictionaryReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37]) as? NSDictionary
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value["result"] as? Int {
-            XCTAssertEqual(result, 79)
-        } else {
-            XCTFail("Value not found")
-        }
     }
 
     func testBindBinaryWithReturnThrows() throws {
@@ -379,142 +179,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
-    func testBindBinaryWithBinaryPrimitiveNSArrayCallback() {
-        binder.bind(binder.target.binaryWithBinaryPrimitiveNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
-            result = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindBinaryWithBinaryPrimitiveNSDictionaryCallback() {
-        binder.bind(binder.target.binaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
-            result = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindBinaryWithBinaryNSArrayPrimitiveCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSArrayPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
-            resultArray = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(37))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindBinaryWithBinaryNSArrayNSArrayCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSArrayNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray1: NSArray?
-        var resultArray2: NSArray?
-        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
-            resultArray1 = value1
-            resultArray2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray1, ["one", "two", "three"])
-        XCTAssertEqual(resultArray2, ["four", "five", "six"])
-    }
-
-    func testBindBinaryWithBinaryNSArrayNSDictionaryCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSArrayNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray: NSArray?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
-            resultArray = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindBinaryWithBinaryNSDictionaryPrimitiveCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
-            resultDict = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(result, .some(37))
-    }
-
-    func testBindBinaryWithBinaryNSDictionaryNSArrayCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSDictionaryNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict: NSDictionary?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
-            resultDict = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindBinaryWithBinaryNSDictionaryNSDictionaryCallback() {
-        binder.bind(binder.target.binaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict1: NSDictionary?
-        var resultDict2: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
-            resultDict1 = value1
-            resultDict2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
-    }
-
     func testBindBinaryWithBinaryCallbackThrows() {
         binder.bind(binder.target.binaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -543,30 +207,6 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(92))
-    }
-
-    func testBindTernaryWithNSArrayReturn() throws {
-        binder.bind(binder.target.ternaryWithNSArrayReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSArray
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value.firstObject as? Int {
-            XCTAssertEqual(result, 92)
-        } else {
-            XCTFail("Value not found")
-        }
-    }
-
-    func testBindTernaryWithNSDictionaryReturn() throws {
-        binder.bind(binder.target.ternaryWithNSDictionaryReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13]) as? NSDictionary
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value["result"] as? Int {
-            XCTAssertEqual(result, 92)
-        } else {
-            XCTFail("Value not found")
-        }
     }
 
     func testBindTernaryWithReturnThrows() throws {
@@ -614,142 +254,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(79))
     }
 
-    func testBindTernaryWithBinaryPrimitiveNSArrayCallback() {
-        binder.bind(binder.target.ternaryWithBinaryPrimitiveNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
-            result = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindTernaryWithBinaryPrimitiveNSDictionaryCallback() {
-        binder.bind(binder.target.ternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
-            result = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(42))
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindTernaryWithBinaryNSArrayPrimitiveCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSArrayPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
-            resultArray = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(37))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindTernaryWithBinaryNSArrayNSArrayCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSArrayNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray1: NSArray?
-        var resultArray2: NSArray?
-        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
-            resultArray1 = value1
-            resultArray2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray1, ["one", "two", "three"])
-        XCTAssertEqual(resultArray2, ["four", "five", "six"])
-    }
-
-    func testBindTernaryWithBinaryNSArrayNSDictionaryCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray: NSArray?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
-            resultArray = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindTernaryWithBinaryNSDictionaryPrimitiveCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
-            resultDict = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(result, .some(37))
-    }
-
-    func testBindTernaryWithBinaryNSDictionaryNSArrayCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict: NSDictionary?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
-            resultDict = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindTernaryWithBinaryNSDictionaryNSDictionaryCallback() {
-        binder.bind(binder.target.ternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict1: NSDictionary?
-        var resultDict2: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
-            resultDict1 = value1
-            resultDict2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
-    }
-
     func testBindTernaryWithBinaryCallbackThrows() {
         binder.bind(binder.target.ternaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -778,30 +282,6 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(99))
-    }
-
-    func testBindQuaternaryWithNSArrayReturn() throws {
-        binder.bind(binder.target.quaternaryWithNSArrayReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSArray
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value.firstObject as? Int {
-            XCTAssertEqual(result, 99)
-        } else {
-            XCTFail("Value not found")
-        }
-    }
-
-    func testBindQuaternaryWithNSDictionaryReturn() throws {
-        binder.bind(binder.target.quaternaryWithNSDictionaryReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13, 7]) as? NSDictionary
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value["result"] as? Int {
-            XCTAssertEqual(result, 99)
-        } else {
-            XCTFail("Value not found")
-        }
     }
 
     func testBindQuaternaryWithReturnThrows() throws {
@@ -849,142 +329,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(92))
     }
 
-    func testBindQuaternaryWithBinaryPrimitiveNSArrayCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryPrimitiveNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
-            result = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(55))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuaternaryWithBinaryPrimitiveNSDictionaryCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
-            result = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(55))
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindQuaternaryWithBinaryNSArrayPrimitiveCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSArrayPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
-            resultArray = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(37))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuaternaryWithBinaryNSArrayNSArrayCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSArrayNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray1: NSArray?
-        var resultArray2: NSArray?
-        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
-            resultArray1 = value1
-            resultArray2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray1, ["one", "two", "three"])
-        XCTAssertEqual(resultArray2, ["four", "five", "six"])
-    }
-
-    func testBindQuaternaryWithBinaryNSArrayNSDictionaryCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSArrayNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray: NSArray?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
-            resultArray = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindQuaternaryWithBinaryNSDictionaryPrimitiveCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
-            resultDict = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(result, .some(37))
-    }
-
-    func testBindQuaternaryWithBinaryNSDictionaryNSArrayCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSDictionaryNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict: NSDictionary?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
-            resultDict = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuaternaryWithBinaryNSDictionaryNSDictionaryCallback() {
-        binder.bind(binder.target.quaternaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict1: NSDictionary?
-        var resultDict2: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
-            resultDict1 = value1
-            resultDict2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
-    }
-
     func testBindQuaternaryWithBinaryCallbackThrows() {
         binder.bind(binder.target.quaternaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -1013,30 +357,6 @@ class BinderTests: XCTestCase {
         let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? Int
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(100))
-    }
-
-    func testBindQuinaryWithNSArrayReturn() throws {
-        binder.bind(binder.target.quinaryWithNSArrayReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSArray
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value.firstObject as? Int {
-            XCTAssertEqual(result, 100)
-        } else {
-            XCTFail("Value not found")
-        }
-    }
-
-    func testBindQuinaryWithNSDictionaryReturn() throws {
-        binder.bind(binder.target.quinaryWithNSDictionaryReturn, as: "")
-        let value = try binder.callable?.call(args: [42, 37, 13, 7, 1]) as? NSDictionary
-        XCTAssert(binder.target.called)
-        if let value = value,
-            let result = value["result"] as? Int {
-            XCTAssertEqual(result, 100)
-        } else {
-            XCTFail("Value not found")
-        }
     }
 
     func testBindQuinaryWithReturnThrows() throws {
@@ -1084,142 +404,6 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result, .some(99))
     }
 
-    func testBindQuinaryWithBinaryPrimitiveNSArrayCallback() {
-        binder.bind(binder.target.quinaryWithBinaryPrimitiveNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryPrimitiveNSArrayCallback = { value1, value2 in
-            result = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(55))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuinaryWithBinaryPrimitiveNSDictionaryCallback() {
-        binder.bind(binder.target.quinaryWithBinaryPrimitiveNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryPrimitiveNSDictionaryCallback = { value1, value2 in
-            result = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(55))
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindQuinaryWithBinaryNSArrayPrimitiveCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSArrayPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSArrayPrimitiveCallback = { value1, value2 in
-            resultArray = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(result, .some(44))
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuinaryWithBinaryNSArrayNSArrayCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSArrayNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray1: NSArray?
-        var resultArray2: NSArray?
-        let callback: BindTarget.BinaryNSArrayNSArrayCallback = { value1, value2 in
-            resultArray1 = value1
-            resultArray2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray1, ["one", "two", "three"])
-        XCTAssertEqual(resultArray2, ["four", "five", "six"])
-    }
-
-    func testBindQuinaryWithBinaryNSArrayNSDictionaryCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSArrayNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultArray: NSArray?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSArrayNSDictionaryCallback = { value1, value2 in
-            resultArray = value1
-            resultDict = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-    }
-
-    func testBindQuinaryWithBinaryNSDictionaryPrimitiveCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSDictionaryPrimitiveCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var result: Int?
-        var resultDict: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryPrimitiveCallback = { value1, value2 in
-            resultDict = value1
-            result = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(result, .some(44))
-    }
-
-    func testBindQuinaryWithBinaryNSDictionaryNSArrayCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSDictionaryNSArrayCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict: NSDictionary?
-        var resultArray: NSArray?
-        let callback: BindTarget.BinaryNSDictionaryNSArrayCallback = { value1, value2 in
-            resultDict = value1
-            resultArray = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultArray, ["one", "two", "three"])
-    }
-
-    func testBindQuinaryWithBinaryNSDictionaryNSDictionaryCallback() {
-        binder.bind(binder.target.quinaryWithBinaryNSDictionaryNSDictionaryCallback, as: "")
-        let expecter = expectation(description: "callback")
-        var resultDict1: NSDictionary?
-        var resultDict2: NSDictionary?
-        let callback: BindTarget.BinaryNSDictionaryNSDictionaryCallback = { value1, value2 in
-            resultDict1 = value1
-            resultDict2 = value2
-            expecter.fulfill()
-        }
-        _ = try? binder.callable?.call(args: [42, 37, 13, 7, make_callable(callback)])
-        wait(for: [expecter], timeout: 5)
-        XCTAssert(binder.target.called)
-        XCTAssertEqual(resultDict1, ["one": 1, "two": 2, "three": 3])
-        XCTAssertEqual(resultDict2, ["four": 4, "five": 5, "six": 6])
-    }
-
     func testBindQuinaryWithBinaryCallbackThrows() {
         binder.bind(binder.target.quinaryWithBinaryCallbackThrows, as: "")
         let expecter = expectation(description: "callback")
@@ -1241,16 +425,6 @@ class BindTarget {
 
     typealias UnaryCallback = (Int) -> Void
     typealias BinaryCallback = (Int, Int) -> Void
-    typealias UnaryNSArrayCallback = (NSArray) -> Void
-    typealias UnaryNSDictionaryCallback = (NSDictionary) -> Void
-    typealias BinaryPrimitiveNSArrayCallback = (Int, NSArray) -> Void
-    typealias BinaryPrimitiveNSDictionaryCallback = (Int, NSDictionary) -> Void
-    typealias BinaryNSArrayPrimitiveCallback = (NSArray, Int) -> Void
-    typealias BinaryNSArrayNSArrayCallback = (NSArray, NSArray) -> Void
-    typealias BinaryNSArrayNSDictionaryCallback = (NSArray, NSDictionary) -> Void
-    typealias BinaryNSDictionaryPrimitiveCallback = (NSDictionary, Int) -> Void
-    typealias BinaryNSDictionaryNSArrayCallback = (NSDictionary, NSArray) -> Void
-    typealias BinaryNSDictionaryNSDictionaryCallback = (NSDictionary, NSDictionary) -> Void
 
     func nullaryNoReturn() {
         called = true
@@ -1264,16 +438,6 @@ class BindTarget {
     func nullaryWithReturn() -> String {
         called = true
         return "value"
-    }
-
-    func nullaryWithNSArrayReturn() -> NSArray {
-        called = true
-        return NSArray()
-    }
-
-    func nullaryWithNSDictionaryReturn() -> NSDictionary {
-        called = true
-        return NSDictionary()
     }
 
     func nullaryWithReturnThrows() throws -> String {
@@ -1300,18 +464,6 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func unaryWithNSArrayReturn(arg0: Int) -> NSArray {
-        called = true
-        let arr: NSArray = [arg0]
-        return arr
-    }
-
-    func unaryWithNSDictionaryReturn(arg0: Int) -> NSDictionary {
-        called = true
-        let dict: NSDictionary = ["result": arg0]
-        return dict
-    }
-
     func unaryWithUnaryCallback(callback: @escaping UnaryCallback) {
         called = true
         callback(42)
@@ -1323,73 +475,9 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func unaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
-        called = true
-        let arr: NSArray = ["one", "two", "three"]
-        callback(arr)
-    }
-
-    func unaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
-        called = true
-        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict)
-    }
-
     func unaryWithBinaryCallback(callback: @escaping BinaryCallback) {
         called = true
         callback(42, 37)
-    }
-
-    func unaryWithBinaryPrimitiveNSArrayCallback(callback: @escaping BinaryPrimitiveNSArrayCallback) {
-        called = true
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(42, arr1)
-    }
-
-    func unaryWithBinaryPrimitiveNSDictionaryCallback(callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
-        called = true
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(42, dict1)
-    }
-
-    func unaryWithBinaryNSArrayPrimitiveCallback(callback: @escaping BinaryNSArrayPrimitiveCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        callback(arr0, 37)
-    }
-
-    func unaryWithBinaryNSArrayNSArrayCallback(callback: @escaping BinaryNSArrayNSArrayCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let arr1: NSArray = ["four", "five", "six"]
-        callback(arr0, arr1)
-    }
-
-    func unaryWithBinaryNSArrayNSDictionaryCallback(callback: @escaping BinaryNSArrayNSDictionaryCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arr0, dict1)
-    }
-
-    func unaryWithBinaryNSDictionaryPrimitiveCallback(callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict0, 37)
-    }
-
-    func unaryWithBinaryNSDictionaryNSArrayCallback(callback: @escaping BinaryNSDictionaryNSArrayCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(dict0, arr1)
-    }
-
-    func unaryWithBinaryNSDictionaryNSDictionaryCallback(callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
-        callback(dict0, dict1)
     }
 
     func unaryWithBinaryCallbackThrows(callback: @escaping BinaryCallback) throws {
@@ -1417,18 +505,6 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func binaryWithNSArrayReturn(arg0: Int, arg1: Int) -> NSArray {
-        called = true
-        let arr: NSArray = [arg0 + arg1]
-        return arr
-    }
-
-    func binaryWithNSDictionaryReturn(arg0: Int, arg1: Int) -> NSDictionary {
-        called = true
-        let dict: NSDictionary = ["result": arg0 + arg1]
-        return dict
-    }
-
     func binaryWithUnaryCallback(arg0: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0)
@@ -1440,73 +516,9 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func binaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
-        called = true
-        let arr: NSArray = ["one", "two", "three"]
-        callback(arr)
-    }
-
-    func binaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
-        called = true
-        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict)
-    }
-
     func binaryWithBinaryCallback(arg0: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, 37)
-    }
-
-    func binaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
-        called = true
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(arg0, arr1)
-    }
-
-    func binaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
-        called = true
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arg0, dict1)
-    }
-
-    func binaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        callback(arr0, 37)
-    }
-
-    func binaryWithBinaryNSArrayNSArrayCallback(arg0: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let arr1: NSArray = ["four", "five", "six"]
-        callback(arr0, arr1)
-    }
-
-    func binaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arr0, dict1)
-    }
-
-    func binaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict0, 37)
-    }
-
-    func binaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(dict0, arr1)
-    }
-
-    func binaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
-        callback(dict0, dict1)
     }
 
     func binaryWithBinaryCallbackThrows(arg0: Int, callback: @escaping BinaryCallback) throws {
@@ -1534,18 +546,6 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func ternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int) -> NSArray {
-        called = true
-        let arr: NSArray = [arg0 + arg1 + arg2]
-        return arr
-    }
-
-    func ternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int) -> NSDictionary {
-        called = true
-        let dict: NSDictionary = ["result": arg0 + arg1 + arg2]
-        return dict
-    }
-
     func ternaryWithUnaryCallback(arg0: Int, arg1: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1)
@@ -1557,73 +557,9 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func ternaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
-        called = true
-        let arr: NSArray = ["one", "two", "three"]
-        callback(arr)
-    }
-
-    func ternaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
-        called = true
-        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict)
-    }
-
     func ternaryWithBinaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0, arg1)
-    }
-
-    func ternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
-        called = true
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(arg0, arr1)
-    }
-
-    func ternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
-        called = true
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arg0, dict1)
-    }
-
-    func ternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        callback(arr0, arg1)
-    }
-
-    func ternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let arr1: NSArray = ["four", "five", "six"]
-        callback(arr0, arr1)
-    }
-
-    func ternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arr0, dict1)
-    }
-
-    func ternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict0, arg1)
-    }
-
-    func ternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(dict0, arr1)
-    }
-
-    func ternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
-        callback(dict0, dict1)
     }
 
     func ternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, callback: @escaping BinaryCallback) throws {
@@ -1651,18 +587,6 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func quaternaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSArray {
-        called = true
-        let arr: NSArray = [arg0 + arg1 + arg2 + arg3]
-        return arr
-    }
-
-    func quaternaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) -> NSDictionary {
-        called = true
-        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3]
-        return dict
-    }
-
     func quaternaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2)
@@ -1674,73 +598,9 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func quaternaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
-        called = true
-        let arr: NSArray = ["one", "two", "three"]
-        callback(arr)
-    }
-
-    func quaternaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
-        called = true
-        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict)
-    }
-
     func quaternaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1)
-    }
-
-    func quaternaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
-        called = true
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(arg0 + arg2, arr1)
-    }
-
-    func quaternaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
-        called = true
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arg0 + arg2, dict1)
-    }
-
-    func quaternaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        callback(arr0, arg1)
-    }
-
-    func quaternaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let arr1: NSArray = ["four", "five", "six"]
-        callback(arr0, arr1)
-    }
-
-    func quaternaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arr0, dict1)
-    }
-
-    func quaternaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict0, arg1)
-    }
-
-    func quaternaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(dict0, arr1)
-    }
-
-    func quaternaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
-        callback(dict0, dict1)
     }
 
     func quaternaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, callback: @escaping BinaryCallback) throws {
@@ -1768,18 +628,6 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func quinaryWithNSArrayReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSArray {
-        called = true
-        let arr: NSArray = [arg0 + arg1 + arg2 + arg3 + arg4]
-        return arr
-    }
-
-    func quinaryWithNSDictionaryReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) -> NSDictionary {
-        called = true
-        let dict: NSDictionary = ["result": arg0 + arg1 + arg2 + arg3 + arg4]
-        return dict
-    }
-
     func quinaryWithUnaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping UnaryCallback) {
         called = true
         callback(arg0 + arg1 + arg2 + arg3)
@@ -1791,73 +639,9 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func quinaryWithUnaryNSArrayCallback(callback: @escaping UnaryNSArrayCallback) {
-        called = true
-        let arr: NSArray = ["one", "two", "three"]
-        callback(arr)
-    }
-
-    func quinaryWithUnaryNSDictionaryCallback(callback: @escaping UnaryNSDictionaryCallback) {
-        called = true
-        let dict: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict)
-    }
-
     func quinaryWithBinaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) {
         called = true
         callback(arg0 + arg2, arg1 + arg3)
-    }
-
-    func quinaryWithBinaryPrimitiveNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryPrimitiveNSArrayCallback) {
-        called = true
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(arg0 + arg2, arr1)
-    }
-
-    func quinaryWithBinaryPrimitiveNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryPrimitiveNSDictionaryCallback) {
-        called = true
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arg0 + arg2, dict1)
-    }
-
-    func quinaryWithBinaryNSArrayPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayPrimitiveCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        callback(arr0, arg1 + arg3)
-    }
-
-    func quinaryWithBinaryNSArrayNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayNSArrayCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let arr1: NSArray = ["four", "five", "six"]
-        callback(arr0, arr1)
-    }
-
-    func quinaryWithBinaryNSArrayNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSArrayNSDictionaryCallback) {
-        called = true
-        let arr0: NSArray = ["one", "two", "three"]
-        let dict1: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(arr0, dict1)
-    }
-
-    func quinaryWithBinaryNSDictionaryPrimitiveCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryPrimitiveCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        callback(dict0, arg1 + arg3)
-    }
-
-    func quinaryWithBinaryNSDictionaryNSArrayCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryNSArrayCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let arr1: NSArray = ["one", "two", "three"]
-        callback(dict0, arr1)
-    }
-
-    func quinaryWithBinaryNSDictionaryNSDictionaryCallback(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryNSDictionaryNSDictionaryCallback) {
-        called = true
-        let dict0: NSDictionary = ["one": 1, "two": 2, "three": 3]
-        let dict1: NSDictionary = ["four": 4, "five": 5, "six": 6]
-        callback(dict0, dict1)
     }
 
     func quinaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) throws {


### PR DESCRIPTION
Support for `NSArray` and `NSDictionary` types was added to support a POC but is not actually used. Removing it _significantly_ reduces the complexity of `Binder` by eliminating probably 3/4 of the total overloads. Starting with 2.0 we will explicitly require the use of `Decodable` and `Encodable` only and not support foundation types that use `JSONSerialization`