### PR TITLE
Basic kotlinx-serialization support

### DIFF
--- a/platforms/android/bridge-webview/build.gradle
+++ b/platforms/android/bridge-webview/build.gradle
@@ -3,6 +3,7 @@ import groovy.json.JsonSlurper
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
+apply plugin: 'kotlinx-serialization'
 apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'jacoco-android'
 
@@ -57,6 +58,7 @@ dependencies {
     testImplementation "io.mockk:mockk:1.9.3.kotlin12"
     kaptTest project(":compiler-webview")
 
+    androidTestImplementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
     androidTestImplementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/platforms/android/bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/CallbackTestPlugin.kt
+++ b/platforms/android/bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/CallbackTestPlugin.kt
@@ -30,8 +30,8 @@ class CallbackTestPlugin : Plugin {
     }
 
     @BoundMethod
-    fun callbackWithPrimitiveAndUddtParams(arg: (param0: Int, param1: MochaTests.MochaMessage) -> Unit) {
-        arg(777, MochaTests.MochaMessage())
+    fun callbackWithPrimitiveAndUddtParams(arg: (param0: Int, param1: MochaTests.SerializableMochaMessage) -> Unit) {
+        arg(777, MochaTests.SerializableMochaMessage())
     }
 
     @BoundMethod
@@ -73,12 +73,12 @@ class CallbackTestPlugin : Plugin {
     }
 
     @BoundMethod
-    fun callbackWithDictionaryAndUddtParams(arg: (param0: JSONObject, param1: MochaTests.MochaMessage) -> Unit) {
+    fun callbackWithDictionaryAndUddtParams(arg: (param0: JSONObject, param1: MochaTests.SerializableMochaMessage) -> Unit) {
         val jo = JSONObject()
         jo.put("one", 1)
         jo.put("two", 2)
         jo.put("three", 3)
-        arg(jo, MochaTests.MochaMessage())
+        arg(jo, MochaTests.SerializableMochaMessage())
     }
 
     @BoundMethod

--- a/platforms/android/bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/MochaTests.kt
+++ b/platforms/android/bridge-webview/src/androidTest/java/com/salesforce/nimbus/bridge/webview/MochaTests.kt
@@ -17,6 +17,7 @@ import com.salesforce.nimbus.JSONSerializable
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.toJSONSerializable
+import kotlinx.serialization.Serializable
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -38,6 +39,9 @@ class MochaTests {
             return jsonObject.toString()
         }
     }
+
+    @Serializable
+    data class SerializableMochaMessage(val stringField: String = "This is a string", val intField: Int = 42)
 
     @PluginOptions(name = "mochaTestBridge")
     class MochaTestBridge(private val webView: WebView) : Plugin {

--- a/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
+++ b/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
@@ -8,7 +8,7 @@
 package com.salesforce.nimbus.bridge.webview
 
 import android.webkit.WebView
-import com.salesforce.nimbus.JSONSerializable
+import com.salesforce.nimbus.JavascriptSerializable
 
 /**
  * Asynchronously broadcast a message to subscribers listening on Javascript side.  Message can be
@@ -20,11 +20,11 @@ import com.salesforce.nimbus.JSONSerializable
  * @param completionHandler A block to invoke when script evaluation completes or fails. You do not
  *                          have to pass a closure if you are not interested in getting the callback.
  */
-fun WebView.broadcastMessage(name: String, arg: JSONSerializable? = null, completionHandler: ((result: Int) -> Unit)? = null) {
+fun WebView.broadcastMessage(name: String, arg: JavascriptSerializable<String>? = null, completionHandler: ((result: Int) -> Unit)? = null) {
     val scriptTemplate: String = if (arg != null) {
         """
             try {
-                var value = ${arg.stringify()};
+                var value = ${arg.serialize()};
                 __nimbus.broadcastMessage('$name', value);
             } catch(e) {
                 console.log('Error parsing JSON during a call to broadcastMessage:' + e.toString());

--- a/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/plugins/DeviceInfoPlugin.kt
+++ b/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/plugins/DeviceInfoPlugin.kt
@@ -51,7 +51,7 @@ class DeviceInfoPlugin(context: Context) : Plugin {
         return cachedDeviceInfo
     }
 
-    override fun <JavascriptEngine> customize(runtime: Runtime<JavascriptEngine>) {
+    override fun <JavascriptEngine, SerializedOutputType> customize(runtime: Runtime<JavascriptEngine, SerializedOutputType>) {
 
         // example for how to do customizations on a specific JavascriptEngine (WebView, v8)
         when (runtime.getJavascriptEngine()) {
@@ -61,7 +61,7 @@ class DeviceInfoPlugin(context: Context) : Plugin {
         }
     }
 
-    override fun <JavascriptEngine> cleanup(runtime: Runtime<JavascriptEngine>) {
+    override fun <JavascriptEngine, SerializedOutputType> cleanup(runtime: Runtime<JavascriptEngine, SerializedOutputType>) {
 
         // example for how to do cleanup on a specific JavascriptEngine (WebView, v8)
         when (runtime.getJavascriptEngine()) {

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -1,17 +1,19 @@
 buildscript {
-    ext.kotlin_version = '1.3.61'
+    ext.kotlin_version = '1.3.71'
+    ext.kotlin_serialization_version = '0.20.0'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.1'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18"
         classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath "org.jetbrains.kotlin:kotlin-serialization:$kotlin_version"
     }
 }
 

--- a/platforms/android/compiler-base/build.gradle
+++ b/platforms/android/compiler-base/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     implementation project(':annotations')
     implementation 'com.squareup:kotlinpoet:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0'
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 }
 
 buildscript {

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -19,6 +19,7 @@ import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
+import kotlinx.serialization.Serializable
 import javax.annotation.processing.AbstractProcessor
 import javax.annotation.processing.Messager
 import javax.annotation.processing.ProcessingEnvironment
@@ -51,6 +52,11 @@ abstract class BinderGenerator : AbstractProcessor() {
     abstract val javascriptEngine: ClassName
 
     /**
+     * The [ClassName] of the serialized output type the javascript engine expects
+     */
+    abstract val serializedOutputType: ClassName
+
+    /**
      * The [ClassName] of the annotation for which each bound method will be annotated with
      */
     abstract val functionAnnotationClassName: ClassName?
@@ -69,6 +75,9 @@ abstract class BinderGenerator : AbstractProcessor() {
 
             // get all plugins
             val pluginElements = env.getElementsAnnotatedWith(PluginOptions::class.java)
+
+            // get all serializable elements
+            val serializableElements = env.getElementsAnnotatedWith(Serializable::class.java)
 
             // find any duplicate plugin names
             val duplicates =
@@ -96,7 +105,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                     } else {
 
                         // process each plugin element to create a type spec
-                        val typeSpec = processPluginElement(pluginElement)
+                        val typeSpec = processPluginElement(pluginElement, serializableElements)
 
                         // create the binder class for the plugin
                         FileSpec.builder(
@@ -120,7 +129,8 @@ abstract class BinderGenerator : AbstractProcessor() {
     override fun getSupportedAnnotationTypes(): MutableSet<String> {
         return mutableSetOf(
             BoundMethod::class.java.canonicalName,
-            PluginOptions::class.java.canonicalName
+            PluginOptions::class.java.canonicalName,
+            Serializable::class.java.canonicalName
         )
     }
 
@@ -128,7 +138,7 @@ abstract class BinderGenerator : AbstractProcessor() {
         return SourceVersion.latestSupported()
     }
 
-    private fun processPluginElement(pluginElement: Element): TypeSpec {
+    private fun processPluginElement(pluginElement: Element, serializableElements: Set<Element>): TypeSpec {
 
         // the binder class name will be <PluginClass><JavascriptEngine>Binder, such as DeviceInfoPluginWebViewBinder
         val binderTypeName = "${pluginElement.getName()}${javascriptEngine.simpleName}Binder"
@@ -154,14 +164,14 @@ abstract class BinderGenerator : AbstractProcessor() {
 
         val stringClassName = String::class.asClassName()
         val runtimeClassName =
-            ClassName(nimbusPackage, "Runtime").parameterizedBy(javascriptEngine)
+            ClassName(nimbusPackage, "Runtime").parameterizedBy(javascriptEngine, serializedOutputType)
 
         // the binder needs to capture the bound target to pass through calls to it
         val type = TypeSpec.classBuilder(binderTypeName)
 
             // the Binder implements Binder<JavascriptEngine>
             .addSuperinterface(
-                ClassName(nimbusPackage, "Binder").parameterizedBy(javascriptEngine)
+                ClassName(nimbusPackage, "Binder").parameterizedBy(javascriptEngine, serializedOutputType)
             )
             .addModifiers(KModifier.PUBLIC)
 
@@ -259,6 +269,7 @@ abstract class BinderGenerator : AbstractProcessor() {
             .map { functionElement ->
                 processFunctionElement(
                     functionElement,
+                    serializableElements,
                     kotlinClass?.functions?.find { it.name == functionElement.getName() }
                 )
             }
@@ -271,6 +282,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
     private fun processFunctionElement(
         functionElement: ExecutableElement,
+        serializableElements: Set<Element>,
         kotlinFunction: KmFunction?
     ): FunSpec {
         val functionName = functionElement.simpleName.toString()
@@ -326,6 +338,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                             } else {
                                 processFunctionParameter(
                                     declaredType,
+                                    serializableElements,
                                     parameter,
                                     kotlinParameter,
                                     funSpec
@@ -351,6 +364,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                         else -> {
                             processOtherDeclaredParameter(
                                 declaredType,
+                                serializableElements,
                                 parameter,
                                 kotlinParameter,
                                 funSpec
@@ -392,6 +406,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                     else -> {
                         processOtherDeclaredReturnType(
                             functionElement,
+                            serializableElements,
                             argsString,
                             kotlinReturnType,
                             funSpec
@@ -435,6 +450,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
     protected open fun processFunctionParameter(
         declaredType: DeclaredType,
+        serializableElements: Set<Element>,
         parameter: VariableElement,
         kotlinParameter: KmValueParameter?,
         funSpec: FunSpec.Builder
@@ -457,8 +473,8 @@ abstract class BinderGenerator : AbstractProcessor() {
                 "val args = arrayOf<%T>(\n",
                 ClassName(
                     nimbusPackage,
-                    "JSONSerializable"
-                ).nullable(true)
+                    "JavascriptSerializable"
+                ).parameterizedBy(serializedOutputType).nullable(true)
             )
             .indent()
             .add(
@@ -472,7 +488,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
         // loop through each argument (except for last)
         // and add to the array created above
-        declaredType.typeArguments.dropLast(1).forEachIndexed { index, typeMirror ->
+        declaredType.typeArguments.dropLast(1).forEachIndexed { index, parameterType ->
 
             // try to get the type from the kotlin class metadata
             // to determine if it is nullable
@@ -494,20 +510,44 @@ abstract class BinderGenerator : AbstractProcessor() {
                 )
             }
 
-            if (typeMirror.kind == TypeKind.WILDCARD) {
-                val wild = typeMirror as WildcardType
+            if (parameterType.kind == TypeKind.WILDCARD) {
+                val wild = parameterType as WildcardType
                 val supertypes =
                     processingEnv.typeUtils.directSupertypes(
                         wild.superBound
                     )
 
-                // if the parameter implements JSONSerializable we are good
-                if (supertypes.any { it.toString() == "$nimbusPackage.JSONSerializable" }) {
-                    argBlock.add("arg$index")
-                } else {
+                when {
 
-                    // if it does not then we nee to wrap it in a PrimitiveJSONSerializable
-                    wrapValueInPrimitiveJSONSerializable()
+                    // if the parameter implements JSONSerializable we are good
+                    supertypes.any { it.toString() == "$nimbusPackage.JSONSerializable" } -> {
+                        argBlock.add("arg$index")
+                    }
+
+                    // if the parameter is serializable then wrap it in a KotlinJSONSerializable
+                    serializableElements.map { it.asRawTypeName() }.any {
+                        it == parameterType.superBound.asRawTypeName(
+                            kotlinTypeNullable
+                        )
+                    } -> {
+                        argBlock.add(
+                            if (kotlinTypeNullable) {
+                                "arg$index?.let { %T(arg$index, %T.serializer()) }"
+                            } else {
+                                "%T(arg$index, %T.serializer())"
+                            },
+                            ClassName(
+                                nimbusPackage,
+                                "KotlinJSONSerializable"
+                            ),
+                            parameterType.superBound.asRawTypeName()
+                        )
+                    }
+                    else -> {
+
+                        // if it does not then we nee to wrap it in a PrimitiveJSONSerializable
+                        wrapValueInPrimitiveJSONSerializable()
+                    }
                 }
             } else {
                 wrapValueInPrimitiveJSONSerializable()
@@ -620,25 +660,55 @@ abstract class BinderGenerator : AbstractProcessor() {
 
     protected open fun processOtherDeclaredParameter(
         declaredType: DeclaredType,
+        serializableElements: Set<Element>,
         parameter: VariableElement,
         kotlinParameter: KmValueParameter?,
         funSpec: FunSpec.Builder
     ) {
+        val supertypes =
+            processingEnv.typeUtils.directSupertypes(declaredType)
 
-        // TODO: we also want to support kotlinx.serializable eventually
+        when {
+            supertypes.any { it.toString() == "$nimbusPackage.JSONSerializable" } -> {
+                val companion = processingEnv.typeUtils.asElement(declaredType).enclosedElements.find { it.getName() == "Companion" }
+                val hasFromJson = companion?.enclosedElements?.any { it.getName() == "fromJSON" } ?: false
 
-        // The Binder will fail to compile if a static `fromJSON` method is not found.
-        // Probably want to emit an error from the annotation processor to fail faster.
-        funSpec.addParameter(
-            "${parameter.getName()}String",
-            String::class
-        )
-        funSpec.addStatement(
-            "val %N = %T.fromJSON(%NString)",
-            parameter.simpleName,
-            parameter.asKotlinType(),
-            parameter.simpleName
-        )
+                // convert from json if there is a fromJSON function
+                if (hasFromJson) {
+                    funSpec.addParameter(
+                        "${parameter.getName()}String",
+                        String::class
+                    )
+                    funSpec.addStatement(
+                        "val %N = %T.fromJSON(%NString)",
+                        parameter.simpleName,
+                        parameter.asKotlinType(),
+                        parameter.simpleName
+                    )
+                } else {
+                    error(
+                        parameter,
+                        "Class for parameter ${parameter.simpleName} must have a static fromJSON function."
+                    )
+                }
+            }
+            serializableElements.map { it.asRawTypeName() }.any {
+                it == declaredType.asRawTypeName()
+            } -> {
+                funSpec.addParameter(
+                    "${parameter.getName()}String",
+                    String::class
+                )
+                funSpec.addStatement(
+                    "val %N = %T(%T.Stable).parse(%T.serializer(), %NString)",
+                    parameter.simpleName,
+                    ClassName("kotlinx.serialization.json", "Json"),
+                    ClassName("kotlinx.serialization.json", "JsonConfiguration"),
+                    parameter.asKotlinType(),
+                    parameter.simpleName
+                )
+            }
+        }
     }
 
     protected open fun processVoidReturnType(
@@ -674,6 +744,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
     protected open fun processOtherDeclaredReturnType(
         functionElement: ExecutableElement,
+        serializableElements: Set<Element>,
         argsString: String,
         kotlinReturnType: KmType?,
         funSpec: FunSpec.Builder
@@ -681,39 +752,59 @@ abstract class BinderGenerator : AbstractProcessor() {
         val supertypes =
             processingEnv.typeUtils.directSupertypes(functionElement.returnType)
 
-        // if the parameter implements JSONSerializable we are good
-        if (supertypes.any { it.toString() == "$nimbusPackage.JSONSerializable" }) {
+        when {
 
-            // stringify the return value
-            funSpec.apply {
-                addStatement(
-                    "return target.%N($argsString).stringify()",
+            // if the parameter implements JSONSerializable we are good
+            supertypes.any { it.toString() == "$nimbusPackage.JSONSerializable" } -> {
+
+                // stringify the return value
+                funSpec.apply {
+                    addStatement(
+                        "val json = target.%N($argsString).stringify()",
+                        functionElement.getName()
+                    )
+                    addStatement("return json")
+                    returns(String::class)
+                }
+            }
+            serializableElements.map { it.asRawTypeName() }.any {
+                it == functionElement.returnType.asRawTypeName()
+            } -> {
+                funSpec.apply {
+                    addStatement(
+                        "val json = %T(%T.Stable).stringify(%T.serializer(), target.%N($argsString))",
+                        ClassName("kotlinx.serialization.json", "Json"),
+                        ClassName("kotlinx.serialization.json", "JsonConfiguration"),
+                        functionElement.returnType,
+                        functionElement.getName()
+                    )
+                    addStatement("return json")
+                    returns(String::class)
+                }
+            }
+            else -> {
+
+                // TODO: should we even allow this? what should the behavior be?
+                // Map to nullable parameters if necessary
+                if (functionElement.returnType.asTypeName() is ParameterizedTypeName) {
+                    val parameterizedReturnType =
+                        functionElement.returnType.asKotlinTypeName() as ParameterizedTypeName
+                    val returnType =
+                        parameterizedReturnType.rawType.parameterizedBy(
+                            parameterizedReturnType.typeArguments.mapIndexed { index, type ->
+                                val nullable = kotlinReturnType?.arguments?.get(index).isNullable()
+                                type.toKotlinTypeName(nullable = nullable)
+                            }
+                        )
+                    funSpec.returns(returnType)
+                } else {
+                    funSpec.returns(functionElement.returnType.asKotlinTypeName(nullable = kotlinReturnType.isNullable()))
+                }
+                funSpec.addStatement(
+                    "return target.%N($argsString)",
                     functionElement.simpleName.toString()
                 )
-                returns(String::class)
             }
-        } else {
-
-            // TODO: should we even allow this? what should the behavior be?
-            // Map to nullable parameters if necessary
-            if (functionElement.returnType.asTypeName() is ParameterizedTypeName) {
-                val parameterizedReturnType =
-                    functionElement.returnType.asKotlinTypeName() as ParameterizedTypeName
-                val returnType =
-                    parameterizedReturnType.rawType.parameterizedBy(
-                        parameterizedReturnType.typeArguments.mapIndexed { index, type ->
-                            val nullable = kotlinReturnType?.arguments?.get(index).isNullable()
-                            type.toKotlinTypeName(nullable = nullable)
-                        }
-                    )
-                funSpec.returns(returnType)
-            } else {
-                funSpec.returns(functionElement.returnType.asKotlinTypeName(nullable = kotlinReturnType.isNullable()))
-            }
-            funSpec.addStatement(
-                "return target.%N($argsString)",
-                functionElement.simpleName.toString()
-            )
         }
     }
 

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -143,7 +143,7 @@ abstract class BinderGenerator : AbstractProcessor() {
         // the binder class name will be <PluginClass><JavascriptEngine>Binder, such as DeviceInfoPluginWebViewBinder
         val binderTypeName = "${pluginElement.getName()}${javascriptEngine.simpleName}Binder"
         val pluginName = pluginElement.getAnnotation(PluginOptions::class.java).name
-        val pluginTypeName = pluginElement.asKotlinType()
+        val pluginTypeName = pluginElement.asKotlinTypeName()
 
         // read kotlin metadata so we can determine which types are nullable
         val kotlinClass =
@@ -377,7 +377,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                 else -> {
                     error(
                         functionElement,
-                        "${parameter.asKotlinType()} is an unsupported parameter type."
+                        "${parameter.asKotlinTypeName()} is an unsupported parameter type."
                     )
                 }
             }
@@ -433,7 +433,7 @@ abstract class BinderGenerator : AbstractProcessor() {
     ) {
         funSpec.addParameter(
             parameter.getName(),
-            parameter.asKotlinType(nullable = kotlinParameter.isNullable())
+            parameter.asKotlinTypeName(nullable = kotlinParameter.isNullable())
         )
     }
 
@@ -682,7 +682,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                     funSpec.addStatement(
                         "val %N = %T.fromJSON(%NString)",
                         parameter.simpleName,
-                        parameter.asKotlinType(),
+                        parameter.asKotlinTypeName(),
                         parameter.simpleName
                     )
                 } else {
@@ -704,7 +704,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                     parameter.simpleName,
                     ClassName("kotlinx.serialization.json", "Json"),
                     ClassName("kotlinx.serialization.json", "JsonConfiguration"),
-                    parameter.asKotlinType(),
+                    parameter.asKotlinTypeName(),
                     parameter.simpleName
                 )
             }

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
@@ -79,7 +79,7 @@ fun TypeMirror.asRawTypeName(nullable: Boolean = false): TypeName {
 /**
  * Converts a Java [TypeName] from the [Element] to a Kotlin [TypeName]
  */
-fun Element.asKotlinType(nullable: Boolean = false) = asType().asKotlinTypeName(nullable = nullable)
+fun Element.asKotlinTypeName(nullable: Boolean = false) = asType().asKotlinTypeName(nullable = nullable)
 
 /**
  * Converts an [Element] to a [TypeName]

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
@@ -65,9 +65,38 @@ fun TypeName.toKotlinTypeName(nullable: Boolean = false): TypeName {
 fun TypeMirror.asKotlinTypeName(nullable: Boolean = false) = asTypeName().toKotlinTypeName(nullable = nullable)
 
 /**
+ * Converts a Java [TypeMirror] to a raw Kotlin [TypeName]
+ */
+fun TypeMirror.asRawTypeName(nullable: Boolean = false): TypeName {
+    val typeName = asTypeName().toKotlinTypeName(nullable)
+    return if (typeName is ParameterizedTypeName) {
+        typeName.rawType.toKotlinTypeName(nullable)
+    } else {
+        typeName
+    }
+}
+
+/**
  * Converts a Java [TypeName] from the [Element] to a Kotlin [TypeName]
  */
 fun Element.asKotlinType(nullable: Boolean = false) = asType().asKotlinTypeName(nullable = nullable)
+
+/**
+ * Converts an [Element] to a [TypeName]
+ */
+fun Element.asTypeName() = asType().asTypeName()
+
+/**
+ * Converts an [Element] to a raw [TypeName]
+ */
+fun Element.asRawTypeName(): TypeName {
+    val typeName = asType().asTypeName()
+    return if (typeName is ParameterizedTypeName) {
+        typeName.rawType.toKotlinTypeName()
+    } else {
+        typeName.toKotlinTypeName()
+    }
+}
 
 /**
  * Gets the string version of the [Element.getSimpleName]
@@ -90,6 +119,6 @@ fun KmValueParameter?.isNullable(): Boolean = this?.type.isNullable()
 fun KmTypeProjection?.isNullable(): Boolean = this?.type.isNullable()
 
 /**
- * Convenience function to toggle the nullability of a [ClassName]
+ * Convenience function to toggle the nullability of a [TypeName]
  */
-fun ClassName.nullable(nullable: Boolean) = copy(nullable = nullable)
+fun TypeName.nullable(nullable: Boolean) = copy(nullable = nullable)

--- a/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -5,5 +5,6 @@ import com.squareup.kotlinpoet.ClassName
 
 class WebViewBinderGenerator : BinderGenerator() {
     override val javascriptEngine = ClassName("android.webkit", "WebView")
+    override val serializedOutputType = ClassName("kotlin", "String")
     override val functionAnnotationClassName = ClassName("android.webkit", "JavascriptInterface")
 }

--- a/platforms/android/core/build.gradle
+++ b/platforms/android/core/build.gradle
@@ -2,6 +2,7 @@ import groovy.json.JsonSlurper
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlinx-serialization'
 apply plugin: 'org.jetbrains.dokka'
 
 android {
@@ -36,8 +37,9 @@ android {
 }
 
 dependencies {
-    api project(":annotations")
+    implementation project(":annotations")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
     testImplementation 'io.kotlintest:kotlintest-runner-junit4:3.1.5'
     testImplementation 'org.json:json:20190722'
 }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Binder.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Binder.kt
@@ -10,8 +10,9 @@ package com.salesforce.nimbus
 /**
  * Binder interface for the generated [Plugin] binder class. [JavascriptEngine] represents the
  * class which is capable of executing javascript, such as an Android WebView or V8.
+ * [SerializedOutputType] represents the serialized type the [JavascriptEngine] expects.
  */
-interface Binder<JavascriptEngine> {
+interface Binder<JavascriptEngine, SerializedOutputType> {
 
     /**
      * Returns the [Plugin] that this binder is bound to.
@@ -26,10 +27,10 @@ interface Binder<JavascriptEngine> {
     /**
      * Binds to the [Runtime].
      */
-    fun bind(runtime: Runtime<JavascriptEngine>)
+    fun bind(runtime: Runtime<JavascriptEngine, SerializedOutputType>)
 
     /**
      * Unbinds from the [Runtime].
      */
-    fun unbind(runtime: Runtime<JavascriptEngine>)
+    fun unbind(runtime: Runtime<JavascriptEngine, SerializedOutputType>)
 }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Bridge.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Bridge.kt
@@ -2,14 +2,15 @@ package com.salesforce.nimbus
 
 /**
  * Defines an object which will be a bridge between a native [Plugin] and a [JavascriptEngine],
- * such as an Android WebView or V8.
+ * such as an Android WebView or V8. [SerializedOutputType] represents the serialized type the
+ * [JavascriptEngine] expects.
  */
-interface Bridge<JavascriptEngine> {
+interface Bridge<JavascriptEngine, SerializedOutputType> {
 
     /**
      * Adds a plugin [Binder] to the [Bridge].
      */
-    fun add(vararg binder: Binder<JavascriptEngine>)
+    fun add(vararg binder: Binder<JavascriptEngine, SerializedOutputType>)
 
     /**
      * Attaches the [Bridge] to a [JavascriptEngine].

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/JSONSerializable.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/JSONSerializable.kt
@@ -7,6 +7,7 @@
 
 package com.salesforce.nimbus
 
-interface JSONSerializable {
+interface JSONSerializable : JavascriptSerializable<String> {
     fun stringify(): String
+    override fun serialize() = stringify()
 }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/JavascriptSerializable.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/JavascriptSerializable.kt
@@ -1,0 +1,13 @@
+package com.salesforce.nimbus
+
+/**
+ * Defines an object that can be serialized into a javascript representation where the
+ * [SerializedOutputType] is the serialized type the javascript engine expects
+ */
+interface JavascriptSerializable<SerializedOutputType> {
+
+    /**
+     * Serializes the value to the [SerializedOutputType]
+     */
+    fun serialize(): SerializedOutputType
+}

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Plugin.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Plugin.kt
@@ -17,7 +17,7 @@ interface Plugin {
      * Customize the [JavascriptEngine] prior to the plugin being initialized. Do not add any javascript
      * interfaces to the [JavascriptEngine] here. They will be added by the [Bridge].
      */
-    fun <JavascriptEngine> customize(runtime: Runtime<JavascriptEngine>) {
+    fun <JavascriptEngine, SerializedOutputType> customize(runtime: Runtime<JavascriptEngine, SerializedOutputType>) {
         /* default empty implementation so simple plugins don't need to override */
     }
 
@@ -25,7 +25,7 @@ interface Plugin {
      * Do any cleanup of the [JavascriptEngine] necessary for this plugin. Do not remove any javascript
      * interfaces from the [JavascriptEngine] here. They will be removed by the [Bridge].
      */
-    fun <JavascriptEngine> cleanup(runtime: Runtime<JavascriptEngine>) {
+    fun <JavascriptEngine, SerializedOutputType> cleanup(runtime: Runtime<JavascriptEngine, SerializedOutputType>) {
         /* default empty implementation so simple plugins don't need to override */
     }
 }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Promise.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Promise.kt
@@ -1,6 +1,0 @@
-package com.salesforce.nimbus
-
-/**
- * Type alias for a function that represents a javascript Promise
- */
-typealias Promise = ((String?, Any?) -> Unit)

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Runtime.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Runtime.kt
@@ -1,9 +1,10 @@
 package com.salesforce.nimbus
 
 /**
- * Defines an object which will be a runtime for a [JavascriptEngine].
+ * Defines an object which will be a runtime for a [JavascriptEngine] with a [SerializedOutputType]
+ * representing the serialized type that the [JavascriptEngine] expects.
  */
-interface Runtime<JavascriptEngine> {
+interface Runtime<JavascriptEngine, SerializedOutputType> {
 
     /**
      * Get the [JavascriptEngine] powering the [Runtime].
@@ -15,7 +16,7 @@ interface Runtime<JavascriptEngine> {
      */
     fun invoke(
         functionName: String,
-        args: Array<JSONSerializable?> = emptyArray(),
+        args: Array<JavascriptSerializable<SerializedOutputType>?> = emptyArray(),
         callback: ((String?, Any?) -> Unit)?
     )
 }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/SerializableExtensions.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/SerializableExtensions.kt
@@ -33,7 +33,7 @@ class PrimitiveJSONSerializable(val value: Any) :
  * A [JSONSerializable] wrapper around an object that is [Serializable] and serialized using a
  * [KSerializer]
  */
-class KotlinJSONSerializable<T>(private val value: T, private val serializer: KSerializer<T>): JSONSerializable {
+class KotlinJSONSerializable<T>(private val value: T, private val serializer: KSerializer<T>) : JSONSerializable {
     override fun stringify(): String {
         return Json(JsonConfiguration.Stable).stringify(serializer, value)
     }

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/SerializableExtensions.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/SerializableExtensions.kt
@@ -7,11 +7,13 @@
 
 package com.salesforce.nimbus
 
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonConfiguration
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.HashMap
 
-// Making this internal so it's not a footgun to consumers
 class PrimitiveJSONSerializable(val value: Any) :
     JSONSerializable {
     private val stringifiedValue: String
@@ -24,6 +26,16 @@ class PrimitiveJSONSerializable(val value: Any) :
 
     override fun stringify(): String {
         return stringifiedValue
+    }
+}
+
+/**
+ * A [JSONSerializable] wrapper around an object that is [Serializable] and serialized using a
+ * [KSerializer]
+ */
+class KotlinJSONSerializable<T>(private val value: T, private val serializer: KSerializer<T>): JSONSerializable {
+    override fun stringify(): String {
+        return Json(JsonConfiguration.Stable).stringify(serializer, value)
     }
 }
 


### PR DESCRIPTION
This adds basic kotlinx-serialization support along side the existing `JSONSerializable` way of serializing to/from a `WebView`. This allows you to just annotate a class with the Kotlin annotation `@Serializable` and in most basic cases the serialization & deserialization will just work. More advanced cases with generic types are currently not supported due to an open [bug](https://github.com/Kotlin/kotlinx.serialization/issues/685) where generic serialization is broken when using `kapt`. More advanced cases can be added later or can currently be accomplished using the existing `JSONSerializable` serialization.

### Changes
- Added kotlinx-serialization to the project
- Created new `JavascriptSerializable` interface which takes a `SerializedOutputType` type representing the type that the output is serialized to (`String` in the case of a `WebView`)
- `JSONSerializable` extends `JavascriptSerializable` to serialize to a `String`
- Added a `KotlinJSONSerializable` which wraps a kotlin `@Serializable` value and serializes using the kotlin serializer
- Updated `MochaTests` to add a couple of serializable parameters
- Updated Kotlin to `1.3.71` and Android Gradle Plugin to `3.6.2` (latest stable)