### PR TITLE
Use central version when uploading to bintray

### DIFF
--- a/packages/nimbus-bridge/package-lock.json
+++ b/packages/nimbus-bridge/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nimbus-bridge",
-    "version": "1.0.0",
+    "version": "2.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/platforms/android/gradle/publishing.gradle
+++ b/platforms/android/gradle/publishing.gradle
@@ -1,3 +1,5 @@
+import groovy.json.JsonSlurper
+
 apply plugin: 'com.jfrog.bintray'
 
 // Android projects need enhanced maven plugin
@@ -47,10 +49,14 @@ install {
 
 
 bintray {
+    def versionFile = file('../../../lerna.json')
+    def parsedVersion = new JsonSlurper().parseText(versionFile.text)
+    def versionToPublish = parsedVersion.version.toString()
     user = project.findProperty('bintrayUser') ?: System.getenv('BINTRAY_USER')
     key = project.findProperty('bintrayApiKey') ?: System.getenv('BINTRAY_API_KEY')
     configurations = ['archives']
     publish = true
+    dryRun = false
     pkg {
         name = project.name
         repo = BINTRAY_REPO
@@ -59,7 +65,7 @@ bintray {
         vcsUrl = POM_SCM_URL
         labels = ['android', 'salesforce', 'hybrid']
         version {
-            name = project.version
+            name = versionToPublish
             released = new Date()
         }
     }


### PR DESCRIPTION
Previously, the bintray uploader was using the version defined in the gradle settings file to upload to bintray as. This changes it to use the central defined version. I've tested this with the dry-run flag.