### PR TITLE
Added Bridge Builder classes, extension functions to clean up api

### DIFF
--- a/platforms/android/bridge-v8/src/main/java/com/salesforce/nimbus/bridge/v8/V8Extensions.kt
+++ b/platforms/android/bridge-v8/src/main/java/com/salesforce/nimbus/bridge/v8/V8Extensions.kt
@@ -51,3 +51,11 @@ fun V8.rejectPromise(error: String): V8Object {
  * Helper function to create a [V8Object] which aids in testability.
  */
 fun V8.createObject() = V8Object(this)
+
+/**
+ * Creates a [V8Bridge.Builder] and passes it to the [builder] function, allowing any binders to be added
+ * and then attaches to the [V8Bridge] instance.
+ */
+fun V8.bridge(builder: V8Bridge.Builder.() -> Unit = {}): V8Bridge {
+    return V8Bridge.Builder().apply(builder).attach(this)
+}

--- a/platforms/android/bridge-v8/src/test/java/com/salesforce/nimbus/bridge/v8/V8BridgeTest.kt
+++ b/platforms/android/bridge-v8/src/test/java/com/salesforce/nimbus/bridge/v8/V8BridgeTest.kt
@@ -47,13 +47,14 @@ class V8BridgeTest {
             every { add(any(), any<V8Object>()) } returns this
         }
 
-        v8Bridge = V8Bridge()
-        v8Bridge.add(mockPlugin1V8Binder, mockPlugin2V8Binder)
+        v8Bridge = V8Bridge.Builder()
+            .bind(mockPlugin1V8Binder)
+            .bind(mockPlugin2V8Binder)
+            .attach(mockV8)
     }
 
     @Test
     fun attachAddsNimbusBridgeObject() {
-        v8Bridge.attach(mockV8)
         slot<V8Object>().let {
 
             // verify bridge object is added
@@ -67,7 +68,6 @@ class V8BridgeTest {
 
     @Test
     fun attachAddsInternalNimbusBridgeObject() {
-        v8Bridge.attach(mockV8)
         slot<V8Object>().let {
 
             // verify internal bridge object is added
@@ -82,21 +82,18 @@ class V8BridgeTest {
 
     @Test
     fun attachAllowsPluginsToCustomize() {
-        v8Bridge.attach(mockV8)
         verify { mockPlugin1.customize(v8Bridge) }
         verify { mockPlugin2.customize(v8Bridge) }
     }
 
     @Test
     fun attachBindsToBinders() {
-        v8Bridge.attach(mockV8)
         verify { mockPlugin1V8Binder.bind(v8Bridge) }
         verify { mockPlugin2V8Binder.bind(v8Bridge) }
     }
 
     @Test
     fun detachCleansUpPlugins() {
-        v8Bridge.attach(mockV8)
         v8Bridge.detach()
         verify { mockPlugin1.cleanup(v8Bridge) }
         verify { mockPlugin2.cleanup(v8Bridge) }
@@ -104,7 +101,6 @@ class V8BridgeTest {
 
     @Test
     fun detachClosesObjects() {
-        v8Bridge.attach(mockV8)
 
         // capture the nimbusBridge object
         val nimbusBridgeSlot = slot<V8Object>()

--- a/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
+++ b/platforms/android/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewExtensions.kt
@@ -39,3 +39,11 @@ fun WebView.broadcastMessage(name: String, arg: JSEncodable<String>? = null, com
         }
     }
 }
+
+/**
+ * Creates a [WebViewBridge.Builder] and passes it to the [builder] function, allowing any binders to be added
+ * and then attaches to the [WebView] instance.
+ */
+fun WebView.bridge(builder: WebViewBridge.Builder.() -> Unit): WebViewBridge {
+    return WebViewBridge.Builder().apply(builder).attach(this)
+}

--- a/platforms/android/bridge-webview/src/test/java/com/salesforce/nimbus/bridge/webview/WebViewBridgeTest.kt
+++ b/platforms/android/bridge-webview/src/test/java/com/salesforce/nimbus/bridge/webview/WebViewBridgeTest.kt
@@ -39,53 +39,48 @@ class WebViewBridgeTest {
 
     @Before
     fun setUp() {
-        webViewBridge = WebViewBridge()
-        webViewBridge.add(mockPlugin1WebViewBinder, mockPlugin2WebViewBinder)
+        webViewBridge = WebViewBridge.Builder()
+            .bind(mockPlugin1WebViewBinder)
+            .bind(mockPlugin2WebViewBinder)
+            .attach(mockWebView)
     }
 
     @Test
     fun attachEnablesJavascript() {
-        webViewBridge.attach(mockWebView)
         verify { mockWebSettings.javaScriptEnabled = true }
     }
 
     @Test
     fun attachAddsNimbusBridgeJavascriptInterface() {
-        webViewBridge.attach(mockWebView)
         verify { mockWebView.addJavascriptInterface(webViewBridge, "_nimbus") }
     }
 
     @Test
     fun attachAllowsPluginsToCustomize() {
-        webViewBridge.attach(mockWebView)
         verify { mockPlugin1.customize(webViewBridge) }
         verify { mockPlugin2.customize(webViewBridge) }
     }
 
     @Test
     fun attachBindsToBinders() {
-        webViewBridge.attach(mockWebView)
         verify { mockPlugin1WebViewBinder.bind(webViewBridge) }
         verify { mockPlugin2WebViewBinder.bind(webViewBridge) }
     }
 
     @Test
     fun attachAddsBinderJavascriptInterfaces() {
-        webViewBridge.attach(mockWebView)
         verify { mockWebView.addJavascriptInterface(ofType(Plugin1WebViewBinder::class), eq("_Test")) }
         verify { mockWebView.addJavascriptInterface(ofType(Plugin2WebViewBinder::class), eq("_Test2")) }
     }
 
     @Test
     fun detachRemovesNimbusBridgeJavascriptInterface() {
-        webViewBridge.attach(mockWebView)
         webViewBridge.detach()
         verify { mockWebView.removeJavascriptInterface("_nimbus") }
     }
 
     @Test
     fun detachCleansUpPlugins() {
-        webViewBridge.attach(mockWebView)
         webViewBridge.detach()
         verify { mockPlugin1.cleanup(webViewBridge) }
         verify { mockPlugin2.cleanup(webViewBridge) }
@@ -93,7 +88,6 @@ class WebViewBridgeTest {
 
     @Test
     fun detachUnbindsFromBinders() {
-        webViewBridge.attach(mockWebView)
         webViewBridge.detach()
         verify { mockPlugin1WebViewBinder.unbind(webViewBridge) }
         verify { mockPlugin2WebViewBinder.unbind(webViewBridge) }
@@ -101,7 +95,6 @@ class WebViewBridgeTest {
 
     @Test
     fun detachRemovesBinderJavascriptInterfaces() {
-        webViewBridge.attach(mockWebView)
         webViewBridge.detach()
         verify { mockWebView.removeJavascriptInterface("_Test") }
         verify { mockWebView.removeJavascriptInterface("_Test2") }
@@ -109,7 +102,6 @@ class WebViewBridgeTest {
 
     @Test
     fun makeCallbackReturnsCallbackWhenWebViewAttached() {
-        webViewBridge.attach(mockWebView)
         val callback = webViewBridge.makeCallback("1")
         assertNotNull(callback)
         assertEquals(mockWebView, callback?.webView)
@@ -118,13 +110,13 @@ class WebViewBridgeTest {
 
     @Test
     fun makeCallbackReturnsNullWhenWebViewNotAttached() {
+        webViewBridge.detach()
         val callback = webViewBridge.makeCallback("1")
         assertNull(callback)
     }
 
     @Test
     fun nativePluginNamesReturnsJsonArrayStringOfNames() {
-        webViewBridge.attach(mockWebView)
         val nativePluginNames = webViewBridge.nativePluginNames()
         assertEquals("[\"Test\",\"Test2\"]", nativePluginNames)
     }

--- a/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -3,6 +3,7 @@ package com.salesforce.nimbus.bridge.v8.compiler
 import com.salesforce.nimbus.compiler.BinderGenerator
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
+import com.salesforce.nimbus.compiler.asTypeName
 import com.salesforce.nimbus.compiler.getName
 import com.salesforce.nimbus.compiler.isNullable
 import com.salesforce.nimbus.compiler.nimbusPackage
@@ -126,6 +127,17 @@ class V8BinderGenerator : BinderGenerator() {
 
     override fun processUnbindFunction(builder: FunSpec.Builder) {
         builder.addStatement("pluginBridge?.close()")
+    }
+
+    override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {
+        return FunSpec.builder("v8Binder")
+            .receiver(pluginElement.asTypeName())
+            .addStatement(
+                "return %T(this)",
+                binderClassName
+            )
+            .returns(binderClassName)
+            .build()
     }
 
     override fun processFunctionElement(

--- a/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -3,6 +3,7 @@ package com.salesforce.nimbus.bridge.webview.compiler
 import com.salesforce.nimbus.compiler.BinderGenerator
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
+import com.salesforce.nimbus.compiler.asTypeName
 import com.salesforce.nimbus.compiler.getName
 import com.salesforce.nimbus.compiler.isNullable
 import com.salesforce.nimbus.compiler.nimbusPackage
@@ -39,6 +40,17 @@ class WebViewBinderGenerator : BinderGenerator() {
 
     private val toJSONEncodableFunctionName = ClassName(nimbusPackage, "toJSONEncodable")
     private val kotlinJSONEncodableClassName = ClassName(nimbusPackage, "KotlinJSONEncodable")
+
+    override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {
+        return FunSpec.builder("webViewBinder")
+            .receiver(pluginElement.asTypeName())
+            .addStatement(
+                "return %T(this)",
+                binderClassName
+            )
+            .returns(binderClassName)
+            .build()
+    }
 
     override fun processFunctionElement(
         functionElement: ExecutableElement,

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Bridge.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Bridge.kt
@@ -8,17 +8,35 @@ package com.salesforce.nimbus
 interface Bridge<JavascriptEngine, EncodedType> {
 
     /**
-     * Adds a plugin [Binder] to the [Bridge].
-     */
-    fun add(vararg binder: Binder<JavascriptEngine, EncodedType>)
-
-    /**
-     * Attaches the [Bridge] to a [JavascriptEngine].
-     */
-    fun attach(javascriptEngine: JavascriptEngine)
-
-    /**
      * Detaches the [Bridge] from a [JavascriptEngine].
      */
     fun detach()
+
+    /**
+     * Abstract builder class for the [Bridge] implementation to implement in order to build a [Bridge] instance.
+     */
+    abstract class Builder<JavascriptEngine, EncodedType, B : Bridge<JavascriptEngine, EncodedType>> {
+        protected val builderBinders = mutableListOf<Binder<JavascriptEngine, EncodedType>>()
+
+        /**
+         * Adds a plugin [Binder] to the [Bridge].
+         */
+        fun bind(binder: Binder<JavascriptEngine, EncodedType>): Builder<JavascriptEngine, EncodedType, B> {
+            builderBinders.add(binder)
+            return this
+        }
+
+        /**
+         * Adds a plugin [Binder] to the [Bridge].
+         */
+        fun bind(builder: Builder<JavascriptEngine, EncodedType, B>.() -> Binder<JavascriptEngine, EncodedType>): Builder<JavascriptEngine, EncodedType, B> {
+            builderBinders.add(builder())
+            return this
+        }
+
+        /**
+         * Attaches the [Bridge] to a [JavascriptEngine].
+         */
+        abstract fun attach(javascriptEngine: JavascriptEngine): B
+    }
 }

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -18,10 +18,12 @@ import com.salesforce.nimbus.BoundMethod
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.bridge.v8.V8Bridge
+import com.salesforce.nimbus.bridge.v8.bridge
 import com.salesforce.nimbus.bridge.webview.WebViewBridge
+import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.core.plugins.DeviceInfoPlugin
-import com.salesforce.nimbus.core.plugins.DeviceInfoPluginV8Binder
-import com.salesforce.nimbus.core.plugins.DeviceInfoPluginWebViewBinder
+import com.salesforce.nimbus.core.plugins.v8Binder
+import com.salesforce.nimbus.core.plugins.webViewBinder
 
 class MainActivity : AppCompatActivity() {
 
@@ -39,9 +41,8 @@ class MainActivity : AppCompatActivity() {
         val deviceInfoPlugin = DeviceInfoPlugin(this)
 
         // create the web view bridge
-        webViewBridge = WebViewBridge().apply {
-            add(DeviceInfoPluginWebViewBinder(deviceInfoPlugin))
-            attach(webView)
+        webViewBridge = webView.bridge {
+            bind { deviceInfoPlugin.webViewBinder() }
         }
 
         // load the demo url
@@ -50,12 +51,15 @@ class MainActivity : AppCompatActivity() {
         // create a v8 runtime
         v8 = V8.createV8Runtime()
 
+        // create some plugins for v8
+        val logPlugin = LogPlugin()
+        val toastPlugin = ToastPlugin(this)
+
         // create the v8 bridge
-        v8Bridge = V8Bridge().apply {
-            add(DeviceInfoPluginV8Binder(deviceInfoPlugin))
-            add(LogPluginV8Binder(LogPlugin()))
-            add(ToastPluginV8Binder(ToastPlugin(this@MainActivity.applicationContext)))
-            attach(v8)
+        v8Bridge = v8.bridge {
+            bind { deviceInfoPlugin.v8Binder() }
+            bind { logPlugin.v8Binder() }
+            bind { toastPlugin.v8Binder() }
         }
 
         // execute a script to get the device info plugin and then log to the console

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8BridgeInvokeTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8BridgeInvokeTests.kt
@@ -3,10 +3,11 @@ package com.salesforce.nimbus.bridge.tests.v8
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.eclipsesource.v8.V8
 import com.google.common.truth.Truth.assertThat
+import com.salesforce.k2v8.scope
 import com.salesforce.nimbus.bridge.tests.withinLatch
 import com.salesforce.nimbus.bridge.v8.V8Bridge
+import com.salesforce.nimbus.bridge.v8.bridge
 import com.salesforce.nimbus.bridge.v8.toV8Encodable
-import com.salesforce.k2v8.scope
 import com.salesforce.nimbus.invoke
 import kotlinx.serialization.Serializable
 import org.junit.After
@@ -38,7 +39,7 @@ class V8BridgeInvokeTests {
     fun setUp() {
         v8 = V8.createV8Runtime()
         v8.executeScript(fixtureScript)
-        bridge = V8Bridge().apply { attach(v8) }
+        bridge = v8.bridge()
     }
 
     @After

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -9,10 +9,10 @@ import com.google.common.truth.Truth.assertThat
 import com.salesforce.k2v8.scope
 import com.salesforce.nimbus.bridge.tests.WebViewActivity
 import com.salesforce.nimbus.bridge.tests.plugin.ExpectPlugin
-import com.salesforce.nimbus.bridge.tests.plugin.ExpectPluginV8Binder
 import com.salesforce.nimbus.bridge.tests.plugin.TestPlugin
-import com.salesforce.nimbus.bridge.tests.plugin.TestPluginV8Binder
+import com.salesforce.nimbus.bridge.tests.plugin.v8Binder
 import com.salesforce.nimbus.bridge.v8.V8Bridge
+import com.salesforce.nimbus.bridge.v8.bridge
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -36,10 +36,9 @@ class V8PluginTests {
     fun setUp() {
         v8 = V8.createV8Runtime()
         expectPlugin = ExpectPlugin()
-        bridge = V8Bridge().apply {
-            add(ExpectPluginV8Binder(expectPlugin))
-            add(TestPluginV8Binder(TestPlugin()))
-            attach(v8)
+        bridge = v8.bridge {
+            bind { expectPlugin.v8Binder() }
+            bind { TestPlugin().v8Binder() }
         }
         v8.scope {
             v8.executeScript("shared-tests".js)

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
@@ -17,9 +17,9 @@ import com.salesforce.nimbus.JSONEncodable
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.bridge.tests.CallbackTestPlugin
-import com.salesforce.nimbus.bridge.tests.CallbackTestPluginWebViewBinder
 import com.salesforce.nimbus.bridge.tests.WebViewActivity
-import com.salesforce.nimbus.bridge.webview.WebViewBridge
+import com.salesforce.nimbus.bridge.tests.webViewBinder
+import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.bridge.webview.broadcastMessage
 import kotlinx.serialization.Serializable
 import org.json.JSONObject
@@ -97,17 +97,12 @@ class WebViewMochaTests {
             )
         val jsAPITest = JSAPITestPlugin()
 
-        val bridge = WebViewBridge()
-
         runOnUiThread {
-            bridge.add(
-                CallbackTestPluginWebViewBinder(
-                    CallbackTestPlugin()
-                )
-            )
-            bridge.add(MochaTestBridgeWebViewBinder(testBridge))
-            bridge.add(JSAPITestPluginWebViewBinder(jsAPITest))
-            bridge.attach(webView)
+            webView.bridge {
+                bind { CallbackTestPlugin().webViewBinder() }
+                bind { testBridge.webViewBinder() }
+                bind { jsAPITest.webViewBinder() }
+            }
             webView.loadUrl("file:///android_asset/test-www/index.html")
         }
 

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -7,12 +7,12 @@ import androidx.test.rule.ActivityTestRule
 import com.google.common.truth.Truth.assertThat
 import com.salesforce.nimbus.bridge.tests.WebViewActivity
 import com.salesforce.nimbus.bridge.tests.plugin.ExpectPlugin
-import com.salesforce.nimbus.bridge.tests.plugin.ExpectPluginWebViewBinder
 import com.salesforce.nimbus.bridge.tests.plugin.TestPlugin
-import com.salesforce.nimbus.bridge.tests.plugin.TestPluginWebViewBinder
+import com.salesforce.nimbus.bridge.tests.plugin.webViewBinder
 import com.salesforce.nimbus.bridge.tests.withTimeoutInSeconds
 import com.salesforce.nimbus.bridge.tests.withinLatch
 import com.salesforce.nimbus.bridge.webview.WebViewBridge
+import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.toJSONEncodable
 import org.junit.After
 import org.junit.Before
@@ -38,12 +38,11 @@ class WebViewPluginTests {
         webView = activityRule.activity.webView
         expectPlugin = ExpectPlugin()
         runOnUiThread {
-            bridge = WebViewBridge().apply {
-                add(ExpectPluginWebViewBinder(expectPlugin))
-                add(TestPluginWebViewBinder(TestPlugin()))
-                attach(webView)
-                webView.loadUrl("file:///android_asset/test-www/shared-tests.html")
+            bridge = webView.bridge {
+                bind { expectPlugin.webViewBinder() }
+                bind { TestPlugin().webViewBinder() }
             }
+            webView.loadUrl("file:///android_asset/test-www/shared-tests.html")
         }
     }
 


### PR DESCRIPTION
The purpose of this PR is to clean up the API for creating/managing a `Bridge` instance. With the previous API it was possible to call `Bridge.add()` to add `Binders` after the bridge had already been attached which meant that those `Binders` would never get bound to the javascript engine. 

Here is an example of this: 
```
val bridge = WebViewBridge()
bridge.attach(webView)
bridge.add(SomePluginBinder(SomePlugin()))
```

The goal was to not allow this but also make the api a bit easier to read/use.

A `Builder` class was added to each `Bridge` implementation and the `Bridge.add()` and `Bridge.attach()` interface functions were removed and moved to the `Builder`. Now, this is what it looks like to create a bridge:

```
val bridge = WebViewBridge.Builder()
    .bind(SomePluginBinder(SomePlugin()))
    .attach(webView)
```

Another nice api change is that there is now an extension function generated on each `Plugin` to create a `Binder` for the plugin. This allows you to access the `Binder` like this:

```
// create WebViewBridge
val webViewBridge = WebViewBridge.Builder()
    .bind(SomePlugin().webViewBinder())
    .attach(webView)

// create V8Bridge
val v8Bridge = V8Bridge.Builder()
    .bind(SomePlugin().v8Binder())
    .attach(v8)
```

Finally, a couple extension functions were added to `WebView` and `V8` to allow creating a bridge in a more Kotlin DSL appropriate way:

```
// create WebViewBridge
val webViewBridge = webView.bridge {
    bind { SomePlugin().webViewBinder() }
}

// create V8Bridge
val v8Bridge = v8.bridge {
    bind { SomePlugin().v8Binder() }
}
```

Using the extension functions also allow the user to not specify `attach()` since the extension function automatically attaches to the receiver (`WebView` or `V8`).