### PR TITLE
Add JSCore Demo Content to DemoApp

### DIFF
--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		CC64245F244619D400604279 /* JSContextConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC64245E244619D400604279 /* JSContextConnectionTests.swift */; };
 		CC64246924479C0400604279 /* JSValueCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC64246824479C0400604279 /* JSValueCallback.swift */; };
 		CC8169582458BCA200E5C0FA /* iife in Resources */ = {isa = PBXBuildFile; fileRef = CC8169562458BB3900E5C0FA /* iife */; };
+		CC88CA232472DF6A009D809F /* JSCoreDemo.js in Resources */ = {isa = PBXBuildFile; fileRef = CC88CA222472DF6A009D809F /* JSCoreDemo.js */; };
+		CC88CA272472E048009D809F /* ConsolePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC88CA262472E048009D809F /* ConsolePlugin.swift */; };
 		CC97224623E4834400F899E7 /* NimbusJS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC97223D23E4834400F899E7 /* NimbusJS.framework */; };
 		CC97224D23E4834400F899E7 /* NimbusJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97224C23E4834400F899E7 /* NimbusJSTests.swift */; };
 		CC97224F23E4834400F899E7 /* NimbusJS.h in Headers */ = {isa = PBXBuildFile; fileRef = CC97223F23E4834400F899E7 /* NimbusJS.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -212,6 +214,8 @@
 		CC64245E244619D400604279 /* JSContextConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextConnectionTests.swift; sourceTree = "<group>"; };
 		CC64246824479C0400604279 /* JSValueCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueCallback.swift; sourceTree = "<group>"; };
 		CC8169562458BB3900E5C0FA /* iife */ = {isa = PBXFileReference; lastKnownFileType = folder; name = iife; path = "../../../../packages/nimbus-bridge/dist/iife"; sourceTree = "<group>"; };
+		CC88CA222472DF6A009D809F /* JSCoreDemo.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = JSCoreDemo.js; sourceTree = "<group>"; };
+		CC88CA262472E048009D809F /* ConsolePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsolePlugin.swift; sourceTree = "<group>"; };
 		CC97223D23E4834400F899E7 /* NimbusJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NimbusJS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC97223F23E4834400F899E7 /* NimbusJS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NimbusJS.h; sourceTree = "<group>"; };
 		CC97224023E4834400F899E7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -342,6 +346,8 @@
 				291A85EC21E52D3E00510832 /* Main.storyboard */,
 				2961103021E54872007058EA /* NimbusApp-Bridging-Header.h */,
 				291A85EA21E52D3E00510832 /* ViewController.swift */,
+				CC88CA222472DF6A009D809F /* JSCoreDemo.js */,
+				CC88CA262472E048009D809F /* ConsolePlugin.swift */,
 			);
 			name = NimbusMobileApp;
 			path = Sources/NimbusMobileApp;
@@ -758,6 +764,7 @@
 				291A85F321E52D4000510832 /* LaunchScreen.storyboard in Resources */,
 				291A85F021E52D4000510832 /* Assets.xcassets in Resources */,
 				291A85EE21E52D3E00510832 /* Main.storyboard in Resources */,
+				CC88CA232472DF6A009D809F /* JSCoreDemo.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -927,6 +934,7 @@
 			files = (
 				291A85EB21E52D3E00510832 /* ViewController.swift in Sources */,
 				291A85E921E52D3E00510832 /* AppDelegate.swift in Sources */,
+				CC88CA272472E048009D809F /* ConsolePlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -6,6 +6,8 @@
 // root or https://opensource.org/licenses/BSD-3-Clause
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 
 public protocol Binder {

--- a/platforms/apple/Sources/Nimbus/CallableBinder.swift
+++ b/platforms/apple/Sources/Nimbus/CallableBinder.swift
@@ -6,6 +6,8 @@
 // root or https://opensource.org/licenses/BSD-3-Clause
 //
 
+// swiftlint:disable identifier_name
+
 typealias Callable = ([Any?]) throws -> Any?
 
 /// Represents an error when the type or number of arguments is incorrect

--- a/platforms/apple/Sources/Nimbus/JSValueCallback.swift
+++ b/platforms/apple/Sources/Nimbus/JSValueCallback.swift
@@ -28,7 +28,7 @@ class JSValueCallback {
     }
 
     func call(args: [Any]) throws {
-        guard let _ = callback?.call(withArguments: args) else {
+        guard let _ = callback?.call(withArguments: args) else { // swiftlint:disable:this unused_optional_binding
             throw JSValueCallbackError.invalidCallback
         }
     }

--- a/platforms/apple/Sources/NimbusMobileApp/ConsolePlugin.swift
+++ b/platforms/apple/Sources/NimbusMobileApp/ConsolePlugin.swift
@@ -1,0 +1,19 @@
+//
+// Copyright (c) 2020, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo
+// root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+import Nimbus
+
+class ConsolePlugin: Plugin {
+    func log(_ line: String) {
+        NSLog("[ConsolePlugin]: " + line)
+    }
+
+    func bind<C>(to connection: C) where C: Connection {
+        connection.bind(log, as: "log")
+    }
+}

--- a/platforms/apple/Sources/NimbusMobileApp/JSCoreDemo.js
+++ b/platforms/apple/Sources/NimbusMobileApp/JSCoreDemo.js
@@ -1,0 +1,3 @@
+__nimbus.plugins.DeviceInfoPlugin.getDeviceInfo().then(function (result) {
+    __nimbus.plugins.ConsolePlugin.log(JSON.stringify(result));
+});

--- a/platforms/apple/Sources/NimbusMobileApp/ViewController.swift
+++ b/platforms/apple/Sources/NimbusMobileApp/ViewController.swift
@@ -18,6 +18,7 @@ class ViewController: UIViewController {
         title = "Nimbus"
         bridge.addPlugin(DeviceInfoPlugin())
         jsBridge.addPlugin(DeviceInfoPlugin())
+        jsBridge.addPlugin(ConsolePlugin())
     }
 
     override func loadView() {
@@ -34,6 +35,10 @@ class ViewController: UIViewController {
 
         if let context = self.context {
             jsBridge.attach(to: context)
+        }
+        if let demoPath = Bundle.main.path(forResource: "JSCoreDemo", ofType: "js"),
+            let demoJS = try? String(contentsOfFile: demoPath), let context = self.context {
+            context.evaluateScript(demoJS)
         }
     }
 

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -11,7 +11,7 @@ import XCTest
 @testable import Nimbus
 
 // repetitive tests are repetitive...
-// swiftlint:disable type_body_length file_length
+// swiftlint:disable type_body_length file_length identifier_name
 
 class BinderTests: XCTestCase {
     let binder = TestBinder()


### PR DESCRIPTION
This adds a simple demo of calling the device info plugin from jscore, then logging the result to another console plugin added in the demo app.