### PR TITLE
iOS Shared Testing

### DIFF
--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		CC6358EC244F808700A9AB39 /* JSEvaluating.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6358EB244F808700A9AB39 /* JSEvaluating.swift */; };
 		CC64245F244619D400604279 /* JSContextConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC64245E244619D400604279 /* JSContextConnectionTests.swift */; };
 		CC64246924479C0400604279 /* JSValueCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC64246824479C0400604279 /* JSValueCallback.swift */; };
+		CC7214CB2474605B00FCCC2D /* SharedTestsWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7214CA2474605B00FCCC2D /* SharedTestsWebView.swift */; };
 		CC8169582458BCA200E5C0FA /* iife in Resources */ = {isa = PBXBuildFile; fileRef = CC8169562458BB3900E5C0FA /* iife */; };
 		CC97224623E4834400F899E7 /* NimbusJS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC97223D23E4834400F899E7 /* NimbusJS.framework */; };
 		CC97224D23E4834400F899E7 /* NimbusJSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC97224C23E4834400F899E7 /* NimbusJSTests.swift */; };
@@ -215,6 +216,7 @@
 		CC6358EB244F808700A9AB39 /* JSEvaluating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSEvaluating.swift; sourceTree = "<group>"; };
 		CC64245E244619D400604279 /* JSContextConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextConnectionTests.swift; sourceTree = "<group>"; };
 		CC64246824479C0400604279 /* JSValueCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueCallback.swift; sourceTree = "<group>"; };
+		CC7214CA2474605B00FCCC2D /* SharedTestsWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestsWebView.swift; sourceTree = "<group>"; };
 		CC8169562458BB3900E5C0FA /* iife */ = {isa = PBXFileReference; lastKnownFileType = folder; name = iife; path = "../../../../packages/nimbus-bridge/dist/iife"; sourceTree = "<group>"; };
 		CC97223D23E4834400F899E7 /* NimbusJS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = NimbusJS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC97223F23E4834400F899E7 /* NimbusJS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NimbusJS.h; sourceTree = "<group>"; };
@@ -393,6 +395,7 @@
 				CC355C0A24367CC200E5FDEE /* PluginTests.swift */,
 				CC39528A2474269D0047BE52 /* SharedTestsJSCore.swift */,
 				CC39528C24745ED10047BE52 /* SharedTestsPlugin.swift */,
+				CC7214CA2474605B00FCCC2D /* SharedTestsWebView.swift */,
 				CC43DB6F2459E3BA0038C0E6 /* JavaScriptCoreGlobals.swift */,
 			);
 			name = NimbusTests;
@@ -973,6 +976,7 @@
 				68B855F2233EE7FD00D1F243 /* BinderTests.swift in Sources */,
 				CC39528B2474269D0047BE52 /* SharedTestsJSCore.swift in Sources */,
 				CC355C0B24367CC200E5FDEE /* PluginTests.swift in Sources */,
+				CC7214CB2474605B00FCCC2D /* SharedTestsWebView.swift in Sources */,
 				CC39528D24745ED10047BE52 /* SharedTestsPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -43,6 +43,8 @@
 		CC216514243C00AE000DC5D3 /* JSValueDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC216513243C00AE000DC5D3 /* JSValueDecoder.swift */; };
 		CC216516243C0395000DC5D3 /* JSValueDecoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC216515243C0395000DC5D3 /* JSValueDecoderTests.swift */; };
 		CC355C0B24367CC200E5FDEE /* PluginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC355C0A24367CC200E5FDEE /* PluginTests.swift */; };
+		CC39528B2474269D0047BE52 /* SharedTestsJSCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC39528A2474269D0047BE52 /* SharedTestsJSCore.swift */; };
+		CC39528D24745ED10047BE52 /* SharedTestsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC39528C24745ED10047BE52 /* SharedTestsPlugin.swift */; };
 		CC430D922433C56000CA12A0 /* WebViewConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC430D902433C39800CA12A0 /* WebViewConnection.swift */; };
 		CC430D932433C56A00CA12A0 /* JSContextBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC430D8E24339B0400CA12A0 /* JSContextBridge.swift */; };
 		CC430D952433C8EF00CA12A0 /* JSContextConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC430D942433C8EF00CA12A0 /* JSContextConnection.swift */; };
@@ -203,6 +205,8 @@
 		CC216513243C00AE000DC5D3 /* JSValueDecoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueDecoder.swift; sourceTree = "<group>"; };
 		CC216515243C0395000DC5D3 /* JSValueDecoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueDecoderTests.swift; sourceTree = "<group>"; };
 		CC355C0A24367CC200E5FDEE /* PluginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginTests.swift; sourceTree = "<group>"; };
+		CC39528A2474269D0047BE52 /* SharedTestsJSCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestsJSCore.swift; sourceTree = "<group>"; };
+		CC39528C24745ED10047BE52 /* SharedTestsPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedTestsPlugin.swift; sourceTree = "<group>"; };
 		CC430D8E24339B0400CA12A0 /* JSContextBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextBridge.swift; sourceTree = "<group>"; };
 		CC430D902433C39800CA12A0 /* WebViewConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebViewConnection.swift; sourceTree = "<group>"; };
 		CC430D942433C8EF00CA12A0 /* JSContextConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSContextConnection.swift; sourceTree = "<group>"; };
@@ -387,6 +391,8 @@
 				CCEA62CA243F83B000664E7E /* JSValueEncoderTests.swift */,
 				29245EE1220CE13000F9EEAF /* MochaTests.swift */,
 				CC355C0A24367CC200E5FDEE /* PluginTests.swift */,
+				CC39528A2474269D0047BE52 /* SharedTestsJSCore.swift */,
+				CC39528C24745ED10047BE52 /* SharedTestsPlugin.swift */,
 				CC43DB6F2459E3BA0038C0E6 /* JavaScriptCoreGlobals.swift */,
 			);
 			name = NimbusTests;
@@ -965,7 +971,9 @@
 				CC64245F244619D400604279 /* JSContextConnectionTests.swift in Sources */,
 				2922900F241165570014B95A /* InvocationTests.swift in Sources */,
 				68B855F2233EE7FD00D1F243 /* BinderTests.swift in Sources */,
+				CC39528B2474269D0047BE52 /* SharedTestsJSCore.swift in Sources */,
 				CC355C0B24367CC200E5FDEE /* PluginTests.swift in Sources */,
+				CC39528D24745ED10047BE52 /* SharedTestsPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platforms/apple/Sources/NimbusTests/JSValueEncoderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/JSValueEncoderTests.swift
@@ -219,7 +219,7 @@ class JSValueEncoderTests: XCTestCase {
         XCTAssertTrue(executeAssertionScript(assertScript, testValue: encoded, key: "valueToTest"))
     }
 
-    func testArrayOfStructs() throws { //swiftlint:disable:this function_body_length
+    func testArrayOfStructs() throws { // swiftlint:disable:this function_body_length
         let one = TestEncodable(foo: 1, bar: "blah", thing: [2], double: 2.0)
         let two = TestEncodable(foo: 2, bar: "blar", thing: [2], double: 3.0)
         let three = TestEncodable(foo: 3, bar: "blam", thing: [3], double: 4.0)

--- a/platforms/apple/Sources/NimbusTests/JSValueEncoderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/JSValueEncoderTests.swift
@@ -90,6 +90,22 @@ class JSValueEncoderTests: XCTestCase {
         XCTAssertTrue(executeAssertionScript(assertScript, testValue: encoded, key: "valueToTest"))
     }
 
+    func testDouble() throws {
+        let testValue: Double = 5.0
+        let encoded = try encoder.encode(testValue, context: context)
+        XCTAssertTrue(encoded.isNumber)
+        let assertScript = """
+        function testValue() {
+            if (valueToTest !== 5.0) {
+                return false
+            }
+            return true
+        }
+        testValue();
+        """
+        XCTAssertTrue(executeAssertionScript(assertScript, testValue: encoded, key: "valueToTest"))
+    }
+
     func testString() throws {
         let testValue = "theteststring"
         let encoded = try encoder.encode(testValue, context: context)
@@ -172,10 +188,11 @@ class JSValueEncoderTests: XCTestCase {
         let foo: Int
         let bar: String
         let thing: [Int]
+        let double: Double
     }
 
     func testBasicStruct() throws {
-        let testValue = TestEncodable(foo: 2, bar: "baz", thing: [1, 2])
+        let testValue = TestEncodable(foo: 2, bar: "baz", thing: [1, 2], double: 3.0)
         let encoded = try encoder.encode(testValue, context: context)
         XCTAssertTrue(encoded.isObject)
         let assertScript = """
@@ -192,7 +209,70 @@ class JSValueEncoderTests: XCTestCase {
             if (valueToTest.thing[1] !== \(testValue.thing[1])) {
                 return false
             }
+            if (valueToTest.double !== \(testValue.double)) {
+                return false
+            }
             return true
+        }
+        testValue();
+        """
+        XCTAssertTrue(executeAssertionScript(assertScript, testValue: encoded, key: "valueToTest"))
+    }
+
+    func testArrayOfStructs() throws { //swiftlint:disable:this function_body_length
+        let one = TestEncodable(foo: 1, bar: "blah", thing: [2], double: 2.0)
+        let two = TestEncodable(foo: 2, bar: "blar", thing: [2], double: 3.0)
+        let three = TestEncodable(foo: 3, bar: "blam", thing: [3], double: 4.0)
+        let testValue = [one, two, three]
+        let encoded = try encoder.encode(testValue, context: context)
+        XCTAssertTrue(encoded.isArray)
+        let assertScript = """
+        function testValue() {
+            var one = valueToTest[0];
+            var two = valueToTest[1];
+            var three = valueToTest[2];
+            if (valueToTest.length !== 3) {
+                return false;
+            }
+            if (one.foo !== \(one.foo)) {
+                return false;
+            }
+            if (one.bar !== "\(one.bar)") {
+                return false;
+            }
+            if (one.thing[0] !== \(one.thing[0])) {
+                return false;
+            }
+            if (one.double !== \(one.double)) {
+                return false;
+            }
+
+            if (two.foo !== \(two.foo)) {
+                return false;
+            }
+            if (two.bar !== "\(two.bar)") {
+                return false;
+            }
+            if (two.thing[0] !== \(two.thing[0])) {
+                return false;
+            }
+            if (two.double !== \(two.double)) {
+                return false;
+            }
+
+            if (three.foo !== \(three.foo)) {
+                return false;
+            }
+            if (three.bar !== "\(three.bar)") {
+                return false;
+            }
+            if (three.thing[0] !== \(three.thing[0])) {
+                return false;
+            }
+            if (three.double !== \(three.double)) {
+                return false;
+            }
+            return true;
         }
         testValue();
         """
@@ -206,7 +286,7 @@ class JSValueEncoderTests: XCTestCase {
     }
 
     func testBasicStructNested() throws {
-        let nest = TestEncodable(foo: 2, bar: "baz", thing: [1, 2])
+        let nest = TestEncodable(foo: 2, bar: "baz", thing: [1, 2], double: 3.0)
         let testValue = TestEncodableNested(foo: 19, bar: "baz", nest: nest)
         let encoded = try encoder.encode(testValue, context: context)
         XCTAssertTrue(encoded.isObject)
@@ -228,6 +308,9 @@ class JSValueEncoderTests: XCTestCase {
                 return false
             }
             if (valueToTest.nest.thing[1] !== \(testValue.nest.thing[1])) {
+                return false
+            }
+            if (valueToTest.nest.double !== \(testValue.nest.double)) {
                 return false
             }
             return true

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -199,10 +199,6 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyNullaryResolvingToIntStructCallback()")
     }
 
-//    func testVerifyNullaryResolvingToDoubleIntStructCallback() {
-//        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
-//    }
-
     func testVerifyUnaryIntResolvingToIntCallback() {
         executeTest("verifyUnaryIntResolvingToIntCallback()")
     }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -31,7 +31,13 @@ class SharedTestsJSCore: XCTestCase {
             context.evaluateScript(jsString)
             context.evaluateScript("__nimbus.plugins.expectPlugin.ready();")
         } else {
-            XCTFail("couldn't get test js")
+            // when running from swiftpm, look for the file relative to the source root
+            let basepath = URL(fileURLWithPath: #file)
+            let url = URL(fileURLWithPath: "../../../../packages/test-www/dist/test-www/shared-tests.js", relativeTo: basepath)
+            if FileManager().fileExists(atPath: url.absoluteURL.path), let script = try? String(contentsOf: url) {
+                context.evaluateScript(script)
+                context.evaluateScript("__nimbus.plugins.expectPlugin.ready();")
+            }
         }
     }
 

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -199,9 +199,9 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyNullaryResolvingToIntStructCallback()")
     }
 
-    func testVerifyNullaryResolvingToDoubleIntStructCallback() {
-        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
-    }
+//    func testVerifyNullaryResolvingToDoubleIntStructCallback() {
+//        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
+//    }
 
     func testVerifyUnaryIntResolvingToIntCallback() {
         executeTest("verifyUnaryIntResolvingToIntCallback()")

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -1,0 +1,213 @@
+//
+// Copyright (c) 2020, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo
+// root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+import JavaScriptCore
+import XCTest
+@testable import Nimbus
+
+class SharedTestsJSCore: XCTestCase {
+    var context = JSContext()!
+    var bridge = JSContextBridge()
+    var expectPlugin = ExpectPlugin()
+    var testPlugin = TestPlugin()
+
+    override func setUp() {
+        expectPlugin = ExpectPlugin()
+        expectPlugin.currentExpectation = expectation(description: "expectPlugin")
+        testPlugin = TestPlugin()
+        context = JSContext()!
+        bridge = JSContextBridge()
+        bridge.addPlugin(expectPlugin)
+        bridge.addPlugin(testPlugin)
+        bridge.attach(to: context)
+
+        if let jsURL = Bundle(for: SharedTestsJSCore.self).url(forResource: "shared-tests", withExtension: "js", subdirectory: "test-www"),
+            let jsString = try? String(contentsOf: jsURL) {
+            context.evaluateScript(jsString)
+            context.evaluateScript("__nimbus.plugins.expectPlugin.ready();")
+        } else {
+            XCTFail("couldn't get test js")
+        }
+    }
+
+    func executeTest(_ testName: String) {
+        XCTAssertTrue(expectPlugin.isReady)
+        context.evaluateScript(testName)
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertTrue(expectPlugin.isFinished)
+        XCTAssertTrue(expectPlugin.passed)
+    }
+
+    func testVerifyNullaryResolvingToInt() {
+        executeTest("verifyNullaryResolvingToInt()")
+    }
+
+    func testVerifyNullaryResolvingToDouble() {
+        executeTest("verifyNullaryResolvingToDouble()")
+    }
+
+    func testVerifyNullaryResolvingToString() {
+        executeTest("verifyNullaryResolvingToString()")
+    }
+
+    func testVerifyNullaryResolvingToStruct() {
+        executeTest("verifyNullaryResolvingToStruct()")
+    }
+
+    func testVerifyNullaryResolvingToIntList() {
+        executeTest("verifyNullaryResolvingToIntList()")
+    }
+
+    func testVerifyNullaryResolvingToDoubleList() {
+        executeTest("verifyNullaryResolvingToDoubleList()")
+    }
+
+    func testVerifyNullaryResolvingToStringList() {
+        executeTest("verifyNullaryResolvingToStringList()")
+    }
+
+    func testVerifyNullaryResolvingToStructList() {
+        executeTest("verifyNullaryResolvingToStructList()")
+    }
+
+    func testVerifyNullaryResolvingToIntArray() {
+        executeTest("verifyNullaryResolvingToIntArray()")
+    }
+
+    func testVerifyNullaryResolvingToStringStringMap() {
+        executeTest("verifyNullaryResolvingToStringStringMap()")
+    }
+
+    func testVerifyNullaryResolvingToStringIntMap() {
+        executeTest("verifyNullaryResolvingToStringIntMap()")
+    }
+
+    func testVerifyNullaryResolvingToStringDoubleMap() {
+        executeTest("verifyNullaryResolvingToStringDoubleMap()")
+    }
+
+    func testVerifyNullaryResolvingToStringStructMap() {
+        executeTest("verifyNullaryResolvingToStringStructMap()")
+    }
+
+    func testVerifyUnaryIntResolvingToInt() {
+        executeTest("verifyUnaryIntResolvingToInt()")
+    }
+
+    func testVerifyUnaryDoubleResolvingToDouble() {
+        executeTest("verifyUnaryDoubleResolvingToDouble()")
+    }
+
+    func testVerifyUnaryStringResolvingToInt() {
+        executeTest("verifyUnaryStringResolvingToInt()")
+    }
+
+    func testVerifyUnaryStructResolvingToJsonString() {
+        executeTest("verifyUnaryStructResolvingToJsonString()")
+    }
+
+    func testVerifyUnaryStringListResolvingToString() {
+        executeTest("verifyUnaryStringListResolvingToString()")
+    }
+
+    func testVerifyUnaryIntListResolvingToString() {
+        executeTest("verifyUnaryIntListResolvingToString()")
+    }
+
+    func testVerifyUnaryDoubleListResolvingToString() {
+        executeTest("verifyUnaryDoubleListResolvingToString()")
+    }
+
+    func testVerifyUnaryStructListResolvingToString() {
+        executeTest("verifyUnaryStructListResolvingToString()")
+    }
+
+    func testVerifyUnaryIntArrayResolvingToString() {
+        executeTest("verifyUnaryIntArrayResolvingToString()")
+    }
+
+    func testVerifyUnaryStringStringMapResolvingToString() {
+        executeTest("verifyUnaryStringStringMapResolvingToString()")
+    }
+
+    func testVerifyUnaryStringStructMapResolvingToString() {
+        executeTest("verifyUnaryStringStructMapResolvingToString()")
+    }
+
+    func testVerifyNullaryResolvingToStringCallback() {
+        executeTest("verifyNullaryResolvingToStringCallback()")
+    }
+
+    func testVerifyNullaryResolvingToIntCallback() {
+        executeTest("verifyNullaryResolvingToIntCallback()")
+    }
+
+    func testVerifyNullaryResolvingToDoubleCallback() {
+        executeTest("verifyNullaryResolvingToDoubleCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStructCallback() {
+        executeTest("verifyNullaryResolvingToStructCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringListCallback() {
+        executeTest("verifyNullaryResolvingToStringListCallback()")
+    }
+
+    func testVerifyNullaryResolvingToIntListCallback() {
+        executeTest("verifyNullaryResolvingToIntListCallback()")
+    }
+
+    func testVerifyNullaryResolvingToDoubleListCallback() {
+        executeTest("verifyNullaryResolvingToDoubleListCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStructListCallback() {
+        executeTest("verifyNullaryResolvingToStructListCallback()")
+    }
+
+    func testVerifyNullaryResolvingToIntArrayCallback() {
+        executeTest("verifyNullaryResolvingToIntArrayCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringStringMapCallback() {
+        executeTest("verifyNullaryResolvingToStringStringMapCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringIntMapCallback() {
+        executeTest("verifyNullaryResolvingToStringIntMapCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringDoubleMapCallback() {
+        executeTest("verifyNullaryResolvingToStringDoubleMapCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringStructMapCallback() {
+        executeTest("verifyNullaryResolvingToStringStructMapCallback()")
+    }
+
+    func testVerifyNullaryResolvingToStringIntCallback() {
+        executeTest("verifyNullaryResolvingToStringIntCallback()")
+    }
+
+    func testVerifyNullaryResolvingToIntStructCallback() {
+        executeTest("verifyNullaryResolvingToIntStructCallback()")
+    }
+
+    func testVerifyNullaryResolvingToDoubleIntStructCallback() {
+        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
+    }
+
+    func testVerifyUnaryIntResolvingToIntCallback() {
+        executeTest("verifyUnaryIntResolvingToIntCallback()")
+    }
+
+    func testVerifyBinaryIntDoubleResolvingToIntDoubleCallback() {
+        executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
+    }
+}

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -18,7 +18,7 @@ class SharedTestsJSCore: XCTestCase {
 
     override func setUp() {
         expectPlugin = ExpectPlugin()
-        expectPlugin.currentExpectation = expectation(description: "expectPlugin")
+        expectPlugin.finishedExpectation = expectation(description: "expectPlugin")
         testPlugin = TestPlugin()
         context = JSContext()!
         bridge = JSContextBridge()

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -133,7 +133,7 @@ class TestPlugin: Plugin {
     }
 
     func unaryStructResolvingToJsonString(param: TestStruct) -> String {
-        return param.asString()
+        return param.asJSONString()
     }
 
     func unaryStringListResolvingToString(param: [String]) -> String {
@@ -157,11 +157,11 @@ class TestPlugin: Plugin {
     }
 
     func unaryStringStringMapResolvingToString(param: [String: String]) -> String {
-        return param.map { "\($0.key), \($0.value)" }.joined(separator: ", ")
+        return param.map { "\($0.key), \($0.value)" }.sorted().joined(separator: ", ")
     }
 
     func unaryStringStructMapResolvingToString(param: [String: TestStruct]) -> String {
-        return param.map { "\($0.key), \($0.value.asString())" }.joined(separator: ", ")
+        return param.map { "\($0.key), \($0.value.asString())" }.sorted().joined(separator: ", ")
     }
 
     func nullaryResolvingToStringCallback(callback: (String) -> Void) {
@@ -316,11 +316,17 @@ struct TestStruct: Codable {
         self.double = double
     }
 
-    func asString() -> String {
-        if let stringData = try? JSONEncoder().encode(self),
+    func asJSONString() -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        if let stringData = try? encoder.encode(self),
             let jsonString = String(data: stringData, encoding: .utf8) {
             return jsonString
         }
         return ""
+    }
+
+    func asString() -> String {
+        return "\(self.string), \(self.integer), \(self.double)"
     }
 }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -268,7 +268,8 @@ class TestPlugin: Plugin {
 }
 
 class ExpectPlugin: Plugin {
-    var currentExpectation: XCTestExpectation?
+    var readyExpectation: XCTestExpectation?
+    var finishedExpectation: XCTestExpectation?
     var isReady = false
     var isFinished = false
     var passed = false
@@ -277,8 +278,15 @@ class ExpectPlugin: Plugin {
         return "expectPlugin"
     }
 
+    func reset() {
+        self.isFinished = false
+        self.passed = false
+        finishedExpectation = nil
+    }
+
     func ready() {
         isReady = true
+        readyExpectation?.fulfill()
     }
 
     func pass() {
@@ -287,7 +295,7 @@ class ExpectPlugin: Plugin {
 
     func finished() {
         isFinished = true
-        currentExpectation?.fulfill()
+        finishedExpectation?.fulfill()
     }
 
     func bind<C>(to connection: C) where C: Connection {

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -14,48 +14,48 @@ class TestPlugin: Plugin {
         return "testPlugin"
     }
 
-    func bind<C>(to connection: C) where C: Connection { //swiftlint:disable:this function_body_length
-        connection.bind(self.nullaryResolvingToInt, as: "nullaryResolvingToInt")
-        connection.bind(self.nullaryResolvingToDouble, as: "nullaryResolvingToDouble")
-        connection.bind(self.nullaryResolvingToString, as: "nullaryResolvingToString")
-        connection.bind(self.nullaryResolvingToStruct, as: "nullaryResolvingToStruct")
-        connection.bind(self.nullaryResolvingToIntList, as: "nullaryResolvingToIntList")
-        connection.bind(self.nullaryResolvingToDoubleList, as: "nullaryResolvingToDoubleList")
-        connection.bind(self.nullaryResolvingToStringList, as: "nullaryResolvingToStringList")
-        connection.bind(self.nullaryResolvingToStructList, as: "nullaryResolvingToStructList")
-        connection.bind(self.nullaryResolvingToIntArray, as: "nullaryResolvingToIntArray")
-        connection.bind(self.nullaryResolvingToStringStringMap, as: "nullaryResolvingToStringStringMap")
-        connection.bind(self.nullaryResolvingToStringIntMap, as: "nullaryResolvingToStringIntMap")
-        connection.bind(self.nullaryResolvingToStringDoubleMap, as: "nullaryResolvingToStringDoubleMap")
-        connection.bind(self.nullaryResolvingToStringStructMap, as: "nullaryResolvingToStringStructMap")
-        connection.bind(self.unaryIntResolvingToInt, as: "unaryIntResolvingToInt")
-        connection.bind(self.unaryDoubleResolvingToDouble, as: "unaryDoubleResolvingToDouble")
-        connection.bind(self.unaryStringResolvingToInt, as: "unaryStringResolvingToInt")
-        connection.bind(self.unaryStructResolvingToJsonString, as: "unaryStructResolvingToJsonString")
-        connection.bind(self.unaryStringListResolvingToString, as: "unaryStringListResolvingToString")
-        connection.bind(self.unaryIntListResolvingToString, as: "unaryIntListResolvingToString")
-        connection.bind(self.unaryDoubleListResolvingToString, as: "unaryDoubleListResolvingToString")
-        connection.bind(self.unaryStructListResolvingToString, as: "unaryStructListResolvingToString")
-        connection.bind(self.unaryIntArrayResolvingToString, as: "unaryIntArrayResolvingToString")
-        connection.bind(self.unaryStringStringMapResolvingToString, as: "unaryStringStringMapResolvingToString")
-        connection.bind(self.unaryStringStructMapResolvingToString, as: "unaryStringStructMapResolvingToString")
-        connection.bind(self.nullaryResolvingToStringCallback, as: "nullaryResolvingToStringCallback")
-        connection.bind(self.nullaryResolvingToIntCallback, as: "nullaryResolvingToIntCallback")
-        connection.bind(self.nullaryResolvingToDoubleCallback, as: "nullaryResolvingToDoubleCallback")
-        connection.bind(self.nullaryResolvingToStructCallback, as: "nullaryResolvingToStructCallback")
-        connection.bind(self.nullaryResolvingToStringListCallback, as: "nullaryResolvingToStringListCallback")
-        connection.bind(self.nullaryResolvingToIntListCallback, as: "nullaryResolvingToIntListCallback")
-        connection.bind(self.nullaryResolvingToDoubleListCallback, as: "nullaryResolvingToDoubleListCallback")
-        connection.bind(self.nullaryResolvingToStructListCallback, as: "nullaryResolvingToStructListCallback")
-        connection.bind(self.nullaryResolvingToIntArrayCallback, as: "nullaryResolvingToIntArrayCallback")
-        connection.bind(self.nullaryResolvingToStringStringMapCallback, as: "nullaryResolvingToStringStringMapCallback")
-        connection.bind(self.nullaryResolvingToStringIntMapCallback, as: "nullaryResolvingToStringIntMapCallback")
-        connection.bind(self.nullaryResolvingToStringDoubleMapCallback, as: "nullaryResolvingToStringDoubleMapCallback")
-        connection.bind(self.nullaryResolvingToStringStructMapCallback, as: "nullaryResolvingToStringStructMapCallback")
-        connection.bind(self.nullaryResolvingToStringIntCallback, as: "nullaryResolvingToStringIntCallback")
-        connection.bind(self.nullaryResolvingToIntStructCallback, as: "nullaryResolvingToIntStructCallback")
-        connection.bind(self.unaryIntResolvingToIntCallback, as: "unaryIntResolvingToIntCallback")
-        connection.bind(self.binaryIntDoubleResolvingToIntDoubleCallback, as: "binaryIntDoubleResolvingToIntDoubleCallback")
+    func bind<C>(to connection: C) where C: Connection { // swiftlint:disable:this function_body_length
+        connection.bind(nullaryResolvingToInt, as: "nullaryResolvingToInt")
+        connection.bind(nullaryResolvingToDouble, as: "nullaryResolvingToDouble")
+        connection.bind(nullaryResolvingToString, as: "nullaryResolvingToString")
+        connection.bind(nullaryResolvingToStruct, as: "nullaryResolvingToStruct")
+        connection.bind(nullaryResolvingToIntList, as: "nullaryResolvingToIntList")
+        connection.bind(nullaryResolvingToDoubleList, as: "nullaryResolvingToDoubleList")
+        connection.bind(nullaryResolvingToStringList, as: "nullaryResolvingToStringList")
+        connection.bind(nullaryResolvingToStructList, as: "nullaryResolvingToStructList")
+        connection.bind(nullaryResolvingToIntArray, as: "nullaryResolvingToIntArray")
+        connection.bind(nullaryResolvingToStringStringMap, as: "nullaryResolvingToStringStringMap")
+        connection.bind(nullaryResolvingToStringIntMap, as: "nullaryResolvingToStringIntMap")
+        connection.bind(nullaryResolvingToStringDoubleMap, as: "nullaryResolvingToStringDoubleMap")
+        connection.bind(nullaryResolvingToStringStructMap, as: "nullaryResolvingToStringStructMap")
+        connection.bind(unaryIntResolvingToInt, as: "unaryIntResolvingToInt")
+        connection.bind(unaryDoubleResolvingToDouble, as: "unaryDoubleResolvingToDouble")
+        connection.bind(unaryStringResolvingToInt, as: "unaryStringResolvingToInt")
+        connection.bind(unaryStructResolvingToJsonString, as: "unaryStructResolvingToJsonString")
+        connection.bind(unaryStringListResolvingToString, as: "unaryStringListResolvingToString")
+        connection.bind(unaryIntListResolvingToString, as: "unaryIntListResolvingToString")
+        connection.bind(unaryDoubleListResolvingToString, as: "unaryDoubleListResolvingToString")
+        connection.bind(unaryStructListResolvingToString, as: "unaryStructListResolvingToString")
+        connection.bind(unaryIntArrayResolvingToString, as: "unaryIntArrayResolvingToString")
+        connection.bind(unaryStringStringMapResolvingToString, as: "unaryStringStringMapResolvingToString")
+        connection.bind(unaryStringStructMapResolvingToString, as: "unaryStringStructMapResolvingToString")
+        connection.bind(nullaryResolvingToStringCallback, as: "nullaryResolvingToStringCallback")
+        connection.bind(nullaryResolvingToIntCallback, as: "nullaryResolvingToIntCallback")
+        connection.bind(nullaryResolvingToDoubleCallback, as: "nullaryResolvingToDoubleCallback")
+        connection.bind(nullaryResolvingToStructCallback, as: "nullaryResolvingToStructCallback")
+        connection.bind(nullaryResolvingToStringListCallback, as: "nullaryResolvingToStringListCallback")
+        connection.bind(nullaryResolvingToIntListCallback, as: "nullaryResolvingToIntListCallback")
+        connection.bind(nullaryResolvingToDoubleListCallback, as: "nullaryResolvingToDoubleListCallback")
+        connection.bind(nullaryResolvingToStructListCallback, as: "nullaryResolvingToStructListCallback")
+        connection.bind(nullaryResolvingToIntArrayCallback, as: "nullaryResolvingToIntArrayCallback")
+        connection.bind(nullaryResolvingToStringStringMapCallback, as: "nullaryResolvingToStringStringMapCallback")
+        connection.bind(nullaryResolvingToStringIntMapCallback, as: "nullaryResolvingToStringIntMapCallback")
+        connection.bind(nullaryResolvingToStringDoubleMapCallback, as: "nullaryResolvingToStringDoubleMapCallback")
+        connection.bind(nullaryResolvingToStringStructMapCallback, as: "nullaryResolvingToStringStructMapCallback")
+        connection.bind(nullaryResolvingToStringIntCallback, as: "nullaryResolvingToStringIntCallback")
+        connection.bind(nullaryResolvingToIntStructCallback, as: "nullaryResolvingToIntStructCallback")
+        connection.bind(unaryIntResolvingToIntCallback, as: "unaryIntResolvingToIntCallback")
+        connection.bind(binaryIntDoubleResolvingToIntDoubleCallback, as: "binaryIntDoubleResolvingToIntDoubleCallback")
     }
 
     func nullaryResolvingToInt() -> Int {
@@ -87,11 +87,10 @@ class TestPlugin: Plugin {
     }
 
     func nullaryResolvingToStructList() -> [TestStruct] {
-
         return [
             TestStruct("1", 1, 1.0),
             TestStruct("2", 2, 2.0),
-            TestStruct("3", 3, 3.0)
+            TestStruct("3", 3, 3.0),
         ]
     }
 
@@ -115,7 +114,7 @@ class TestPlugin: Plugin {
         return [
             "key1": TestStruct("1", 1, 1.0),
             "key2": TestStruct("2", 2, 2.0),
-            "key3": TestStruct("3", 3, 3.0)
+            "key3": TestStruct("3", 3, 3.0),
         ]
     }
 
@@ -196,7 +195,7 @@ class TestPlugin: Plugin {
             [
                 TestStruct("1", 1, 1.0),
                 TestStruct("2", 2, 2.0),
-                TestStruct("3", 3, 3.0)
+                TestStruct("3", 3, 3.0),
             ]
         )
     }
@@ -210,7 +209,7 @@ class TestPlugin: Plugin {
             [
                 "key1": "value1",
                 "key2": "value2",
-                "key3": "value3"
+                "key3": "value3",
             ]
         )
     }
@@ -220,7 +219,7 @@ class TestPlugin: Plugin {
             [
                 "1": 1,
                 "2": 2,
-                "3": 3
+                "3": 3,
             ]
         )
     }
@@ -230,7 +229,7 @@ class TestPlugin: Plugin {
             [
                 "1.0": 1.0,
                 "2.0": 2.0,
-                "3.0": 3.0
+                "3.0": 3.0,
             ]
         )
     }
@@ -240,7 +239,7 @@ class TestPlugin: Plugin {
             [
                 "1": TestStruct("1", 1, 1.0),
                 "2": TestStruct("2", 2, 2.0),
-                "3": TestStruct("3", 3, 3.0)
+                "3": TestStruct("3", 3, 3.0),
             ]
         )
     }
@@ -274,8 +273,8 @@ class ExpectPlugin: Plugin {
     }
 
     func reset() {
-        self.isFinished = false
-        self.passed = false
+        isFinished = false
+        passed = false
         finishedExpectation = nil
     }
 
@@ -294,9 +293,9 @@ class ExpectPlugin: Plugin {
     }
 
     func bind<C>(to connection: C) where C: Connection {
-        connection.bind(self.ready, as: "ready")
-        connection.bind(self.pass, as: "pass")
-        connection.bind(self.finished, as: "finished")
+        connection.bind(ready, as: "ready")
+        connection.bind(pass, as: "pass")
+        connection.bind(finished, as: "finished")
     }
 }
 
@@ -322,6 +321,6 @@ struct TestStruct: Codable {
     }
 
     func asString() -> String {
-        return "\(self.string), \(self.integer), \(self.double)"
+        return "\(string), \(integer), \(double)"
     }
 }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -1,0 +1,318 @@
+//
+// Copyright (c) 2020, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo
+// root or https://opensource.org/licenses/BSD-3-Clause
+//
+
+import XCTest
+@testable import Nimbus
+
+class TestPlugin: Plugin {
+    var namespace: String {
+        return "testPlugin"
+    }
+
+    func bind<C>(to connection: C) where C: Connection { //swiftlint:disable:this function_body_length
+        connection.bind(self.nullaryResolvingToInt, as: "nullaryResolvingToInt")
+        connection.bind(self.nullaryResolvingToDouble, as: "nullaryResolvingToDouble")
+        connection.bind(self.nullaryResolvingToString, as: "nullaryResolvingToString")
+        connection.bind(self.nullaryResolvingToStruct, as: "nullaryResolvingToStruct")
+        connection.bind(self.nullaryResolvingToIntList, as: "nullaryResolvingToIntList")
+        connection.bind(self.nullaryResolvingToDoubleList, as: "nullaryResolvingToDoubleList")
+        connection.bind(self.nullaryResolvingToStringList, as: "nullaryResolvingToStringList")
+        connection.bind(self.nullaryResolvingToStructList, as: "nullaryResolvingToStructList")
+        connection.bind(self.nullaryResolvingToIntArray, as: "nullaryResolvingToIntArray")
+        connection.bind(self.nullaryResolvingToStringStringMap, as: "nullaryResolvingToStringStringMap")
+        connection.bind(self.nullaryResolvingToStringIntMap, as: "nullaryResolvingToStringIntMap")
+        connection.bind(self.nullaryResolvingToStringDoubleMap, as: "nullaryResolvingToStringDoubleMap")
+        connection.bind(self.nullaryResolvingToStringStructMap, as: "nullaryResolvingToStringStructMap")
+        connection.bind(self.unaryIntResolvingToInt, as: "unaryIntResolvingToInt")
+        connection.bind(self.unaryDoubleResolvingToDouble, as: "unaryDoubleResolvingToDouble")
+        connection.bind(self.unaryStringResolvingToInt, as: "unaryStringResolvingToInt")
+        connection.bind(self.unaryStructResolvingToJsonString, as: "unaryStructResolvingToJsonString")
+        connection.bind(self.unaryStringListResolvingToString, as: "unaryStringListResolvingToString")
+        connection.bind(self.unaryIntListResolvingToString, as: "unaryIntListResolvingToString")
+        connection.bind(self.unaryDoubleListResolvingToString, as: "unaryDoubleListResolvingToString")
+        connection.bind(self.unaryStructListResolvingToString, as: "unaryStructListResolvingToString")
+        connection.bind(self.unaryIntArrayResolvingToString, as: "unaryIntArrayResolvingToString")
+        connection.bind(self.unaryStringStringMapResolvingToString, as: "unaryStringStringMapResolvingToString")
+        connection.bind(self.unaryStringStructMapResolvingToString, as: "unaryStringStructMapResolvingToString")
+        connection.bind(self.nullaryResolvingToStringCallback, as: "nullaryResolvingToStringCallback")
+        connection.bind(self.nullaryResolvingToIntCallback, as: "nullaryResolvingToIntCallback")
+        connection.bind(self.nullaryResolvingToDoubleCallback, as: "nullaryResolvingToDoubleCallback")
+        connection.bind(self.nullaryResolvingToStructCallback, as: "nullaryResolvingToStructCallback")
+        connection.bind(self.nullaryResolvingToStringListCallback, as: "nullaryResolvingToStringListCallback")
+        connection.bind(self.nullaryResolvingToIntListCallback, as: "nullaryResolvingToIntListCallback")
+        connection.bind(self.nullaryResolvingToDoubleListCallback, as: "nullaryResolvingToDoubleListCallback")
+        connection.bind(self.nullaryResolvingToStructListCallback, as: "nullaryResolvingToStructListCallback")
+        connection.bind(self.nullaryResolvingToIntArrayCallback, as: "nullaryResolvingToIntArrayCallback")
+        connection.bind(self.nullaryResolvingToStringStringMapCallback, as: "nullaryResolvingToStringStringMapCallback")
+        connection.bind(self.nullaryResolvingToStringIntMapCallback, as: "nullaryResolvingToStringIntMapCallback")
+        connection.bind(self.nullaryResolvingToStringDoubleMapCallback, as: "nullaryResolvingToStringDoubleMapCallback")
+        connection.bind(self.nullaryResolvingToStringStructMapCallback, as: "nullaryResolvingToStringStructMapCallback")
+        connection.bind(self.nullaryResolvingToStringIntCallback, as: "nullaryResolvingToStringIntCallback")
+        connection.bind(self.nullaryResolvingToIntStructCallback, as: "nullaryResolvingToIntStructCallback")
+//        connection.bind(self.nullaryResolvingToIntDoubleStructCallback, as: "nullaryResolvingToIntDoubleStructCallback")
+        connection.bind(self.unaryIntResolvingToIntCallback, as: "unaryIntResolvingToIntCallback")
+        connection.bind(self.binaryIntDoubleResolvingToIntDoubleCallback, as: "binaryIntDoubleResolvingToIntDoubleCallback")
+    }
+
+    func nullaryResolvingToInt() -> Int {
+        return 5
+    }
+
+    func nullaryResolvingToDouble() -> Double {
+        return 10.0
+    }
+
+    func nullaryResolvingToString() -> String {
+        return "aString"
+    }
+
+    func nullaryResolvingToStruct() -> TestStruct {
+        return TestStruct()
+    }
+
+    func nullaryResolvingToIntList() -> [Int] {
+        return [1, 2, 3]
+    }
+
+    func nullaryResolvingToDoubleList() -> [Double] {
+        return [4.0, 5.0, 6.0]
+    }
+
+    func nullaryResolvingToStringList() -> [String] {
+        return ["1", "2", "3"]
+    }
+
+    func nullaryResolvingToStructList() -> [TestStruct] {
+
+        return [
+            TestStruct("1", 1, 1.0),
+            TestStruct("2", 2, 2.0),
+            TestStruct("3", 3, 3.0)
+        ]
+    }
+
+    func nullaryResolvingToIntArray() -> [Int] {
+        return [1, 2, 3]
+    }
+
+    func nullaryResolvingToStringStringMap() -> [String: String] {
+        return ["key1": "value1", "key2": "value2", "key3": "value3"]
+    }
+
+    func nullaryResolvingToStringIntMap() -> [String: Int] {
+        return ["key1": 1, "key2": 2, "key3": 3]
+    }
+
+    func nullaryResolvingToStringDoubleMap() -> [String: Double] {
+        return ["key1": 1.0, "key2": 2.0, "key3": 3.0]
+    }
+
+    func nullaryResolvingToStringStructMap() -> [String: TestStruct] {
+        return [
+            "key1": TestStruct("1", 1, 1.0),
+            "key2": TestStruct("2", 2, 2.0),
+            "key3": TestStruct("3", 3, 3.0)
+        ]
+    }
+
+    func unaryIntResolvingToInt(param: Int) -> Int {
+        return param + 1
+    }
+
+    func unaryDoubleResolvingToDouble(param: Double) -> Double {
+        return param * 2
+    }
+
+    func unaryStringResolvingToInt(param: String) -> Int {
+        return param.count
+    }
+
+    func unaryStructResolvingToJsonString(param: TestStruct) -> String {
+        return param.asString()
+    }
+
+    func unaryStringListResolvingToString(param: [String]) -> String {
+        return param.joined(separator: ", ")
+    }
+
+    func unaryIntListResolvingToString(param: [Int]) -> String {
+        return param.map { String($0) }.joined(separator: ", ")
+    }
+
+    func unaryDoubleListResolvingToString(param: [Double]) -> String {
+        return param.map { String($0) }.joined(separator: ", ")
+    }
+
+    func unaryStructListResolvingToString(param: [TestStruct]) -> String {
+        return param.map { $0.asString() }.joined(separator: ", ")
+    }
+
+    func unaryIntArrayResolvingToString(param: [Int]) -> String {
+        return param.map { String($0) }.joined(separator: ", ")
+    }
+
+    func unaryStringStringMapResolvingToString(param: [String: String]) -> String {
+        return param.map { "\($0.key), \($0.value)" }.joined(separator: ", ")
+    }
+
+    func unaryStringStructMapResolvingToString(param: [String: TestStruct]) -> String {
+        return param.map { "\($0.key), \($0.value.asString())" }.joined(separator: ", ")
+    }
+
+    func nullaryResolvingToStringCallback(callback: (String) -> Void) {
+        callback("param0")
+    }
+
+    func nullaryResolvingToIntCallback(callback: (Int) -> Void) {
+        callback(1)
+    }
+
+    func nullaryResolvingToDoubleCallback(callback: (Double) -> Void) {
+        callback(3.0)
+    }
+
+    func nullaryResolvingToStructCallback(callback: (TestStruct) -> Void) {
+        callback(TestStruct())
+    }
+
+    func nullaryResolvingToStringListCallback(callback: ([String]) -> Void) {
+        callback(["1", "2", "3"])
+    }
+
+    func nullaryResolvingToIntListCallback(callback: ([Int]) -> Void) {
+        callback([1, 2, 3])
+    }
+
+    func nullaryResolvingToDoubleListCallback(callback: ([Double]) -> Void) {
+        callback([1.0, 2.0, 3.0])
+    }
+
+    func nullaryResolvingToStructListCallback(callback: ([TestStruct]) -> Void) {
+        callback(
+            [
+                TestStruct("1", 1, 1.0),
+                TestStruct("2", 2, 2.0),
+                TestStruct("3", 3, 3.0)
+            ]
+        )
+    }
+
+    func nullaryResolvingToIntArrayCallback(callback: ([Int]) -> Void) {
+        callback([1, 2, 3])
+    }
+
+    func nullaryResolvingToStringStringMapCallback(callback: ([String: String]) -> Void) {
+        callback(
+            [
+                "key1": "value1",
+                "key2": "value2",
+                "key3": "value3"
+            ]
+        )
+    }
+
+    func nullaryResolvingToStringIntMapCallback(callback: ([String: Int]) -> Void) {
+        callback(
+            [
+                "1": 1,
+                "2": 2,
+                "3": 3
+            ]
+        )
+    }
+
+    func nullaryResolvingToStringDoubleMapCallback(callback: ([String: Double]) -> Void) {
+        callback(
+            [
+                "1.0": 1.0,
+                "2.0": 2.0,
+                "3.0": 3.0
+            ]
+        )
+    }
+
+    func nullaryResolvingToStringStructMapCallback(callback: ([String: TestStruct]) -> Void) {
+        callback(
+            [
+                "1": TestStruct("1", 1, 1.0),
+                "2": TestStruct("2", 2, 2.0),
+                "3": TestStruct("3", 3, 3.0)
+            ]
+        )
+    }
+
+    func nullaryResolvingToStringIntCallback(callback: (String, Int) -> Void) {
+        callback("param0", 1)
+    }
+
+    func nullaryResolvingToIntStructCallback(callback: (Int, TestStruct) -> Void) {
+        callback(2, TestStruct())
+    }
+
+    func nullaryResolvingToIntDoubleStructCallback(callback: (Int, Double, TestStruct) -> Void) {
+        callback(3, 4.0, TestStruct())
+    }
+
+    func unaryIntResolvingToIntCallback(param: Int, callback: (Int) -> Void) {
+        callback(param + 1)
+    }
+
+    func binaryIntDoubleResolvingToIntDoubleCallback(param0: Int, param1: Double, callback: (Int, Double) -> Void) {
+        callback(param0 + 1, param1 * 2)
+    }
+}
+
+class ExpectPlugin: Plugin {
+    var currentExpectation: XCTestExpectation?
+    var isReady = false
+    var isFinished = false
+    var passed = false
+
+    var namespace: String {
+        return "expectPlugin"
+    }
+
+    func ready() {
+        isReady = true
+    }
+
+    func pass() {
+        passed = true
+    }
+
+    func finished() {
+        isFinished = true
+        currentExpectation?.fulfill()
+    }
+
+    func bind<C>(to connection: C) where C: Connection {
+        connection.bind(self.ready, as: "ready")
+        connection.bind(self.pass, as: "pass")
+        connection.bind(self.finished, as: "finished")
+    }
+}
+
+struct TestStruct: Codable {
+    let string: String
+    let integer: Int
+    let double: Double
+
+    init(_ string: String = "String", _ integer: Int = 1, _ double: Double = 2.0) {
+        self.string = string
+        self.integer = integer
+        self.double = double
+    }
+
+    func asString() -> String {
+        if let stringData = try? JSONEncoder().encode(self),
+            let jsonString = String(data: stringData, encoding: .utf8) {
+            return jsonString
+        }
+        return ""
+    }
+}

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -54,7 +54,6 @@ class TestPlugin: Plugin {
         connection.bind(self.nullaryResolvingToStringStructMapCallback, as: "nullaryResolvingToStringStructMapCallback")
         connection.bind(self.nullaryResolvingToStringIntCallback, as: "nullaryResolvingToStringIntCallback")
         connection.bind(self.nullaryResolvingToIntStructCallback, as: "nullaryResolvingToIntStructCallback")
-//        connection.bind(self.nullaryResolvingToIntDoubleStructCallback, as: "nullaryResolvingToIntDoubleStructCallback")
         connection.bind(self.unaryIntResolvingToIntCallback, as: "unaryIntResolvingToIntCallback")
         connection.bind(self.binaryIntDoubleResolvingToIntDoubleCallback, as: "binaryIntDoubleResolvingToIntDoubleCallback")
     }
@@ -252,10 +251,6 @@ class TestPlugin: Plugin {
 
     func nullaryResolvingToIntStructCallback(callback: (Int, TestStruct) -> Void) {
         callback(2, TestStruct())
-    }
-
-    func nullaryResolvingToIntDoubleStructCallback(callback: (Int, Double, TestStruct) -> Void) {
-        callback(3, 4.0, TestStruct())
     }
 
     func unaryIntResolvingToIntCallback(param: Int, callback: (Int) -> Void) {

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -1,0 +1,117 @@
+//
+//  SharedTestsWebView.swift
+//  NimbusTests
+//
+//  Created by Paul Tiarks on 5/19/20.
+//  Copyright © 2020 Salesforce.com, inc. All rights reserved.
+//
+
+import XCTest
+import WebKit
+@testable import Nimbus
+
+class SharedTestsWebView: XCTestCase {
+    var webView = WKWebView()
+    var bridge = WebViewBridge()
+    var expectPlugin = ExpectPlugin()
+    var testPlugin = TestPlugin()
+
+    override func setUp() {
+        expectPlugin = ExpectPlugin()
+        testPlugin = TestPlugin()
+        webView = WKWebView()
+        bridge = WebViewBridge()
+    }
+
+    func loadWebViewAndWait() {
+        let readyExpectation = expectation(description: "ready")
+        expectPlugin.readyExpectation = readyExpectation
+        bridge.addPlugin(expectPlugin)
+        bridge.addPlugin(testPlugin)
+        bridge.attach(to: webView)
+
+        //load nimbus.js
+        if let jsURL = Bundle(for: SharedTestsWebView.self).url(forResource: "nimbus", withExtension: "js", subdirectory: "iife"),
+            let jsString = try? String(contentsOf: jsURL) {
+            let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            webView.configuration.userContentController.addUserScript(userScript)
+        } else {
+            XCTFail("couldn't get nimbus js")
+        }
+
+        //load shared-tests.js
+        if let jsURL = Bundle(for: SharedTestsWebView.self).url(forResource: "shared-tests", withExtension: "js", subdirectory: "test-www"),
+            let jsString = try? String(contentsOf: jsURL) {
+            let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            webView.configuration.userContentController.addUserScript(userScript)
+        } else {
+            XCTFail("couldn't get test js")
+        }
+
+        // load the html
+        if let htmlURL = Bundle(for: SharedTestsWebView.self).url(forResource: "shared-tests", withExtension: "html", subdirectory: "test-www") {
+            webView.loadFileURL(htmlURL, allowingReadAccessTo: htmlURL)
+        } else {
+            XCTFail("couldn't get the test html")
+        }
+
+        wait(for: [readyExpectation], timeout: 60)
+    }
+
+    func executeTest(_ testName: String) {
+        loadWebViewAndWait()
+        XCTAssertTrue(expectPlugin.isReady)
+        expectPlugin.reset()
+        expectPlugin.finishedExpectation = expectation(description: testName)
+        webView.evaluateJavaScript(testName, completionHandler: nil)
+        waitForExpectations(timeout: 1, handler: nil)
+        XCTAssertTrue(expectPlugin.isFinished)
+        XCTAssertTrue(expectPlugin.passed)
+    }
+
+    func testAllTests() { //swiftlint:disable:this function_body_length
+        executeTest("verifyNullaryResolvingToInt()")
+        executeTest("verifyNullaryResolvingToDouble()")
+        executeTest("verifyNullaryResolvingToDouble()")
+        executeTest("verifyNullaryResolvingToString()")
+        executeTest("verifyNullaryResolvingToStruct()")
+        executeTest("verifyNullaryResolvingToIntList()")
+        executeTest("verifyNullaryResolvingToDoubleList()")
+        executeTest("verifyNullaryResolvingToStringList()")
+        executeTest("verifyNullaryResolvingToStructList()")
+        executeTest("verifyNullaryResolvingToIntArray()")
+        executeTest("verifyNullaryResolvingToStringStringMap()")
+        executeTest("verifyNullaryResolvingToStringIntMap()")
+        executeTest("verifyNullaryResolvingToStringDoubleMap()")
+        executeTest("verifyNullaryResolvingToStringStructMap()")
+        executeTest("verifyUnaryIntResolvingToInt()")
+        executeTest("verifyUnaryDoubleResolvingToDouble()")
+        executeTest("verifyUnaryStringResolvingToInt()")
+        executeTest("verifyUnaryStructResolvingToJsonString()")
+        executeTest("verifyUnaryStringListResolvingToString()")
+        executeTest("verifyUnaryIntListResolvingToString()")
+        executeTest("verifyUnaryDoubleListResolvingToString()")
+        executeTest("verifyUnaryStructListResolvingToString()")
+        executeTest("verifyUnaryIntArrayResolvingToString()")
+        executeTest("verifyUnaryStringStringMapResolvingToString()")
+        executeTest("verifyUnaryStringStructMapResolvingToString()")
+        executeTest("verifyNullaryResolvingToStringCallback()")
+        executeTest("verifyNullaryResolvingToIntCallback()")
+        executeTest("verifyNullaryResolvingToDoubleCallback()")
+        executeTest("verifyNullaryResolvingToStructCallback()")
+        executeTest("verifyNullaryResolvingToStringListCallback()")
+        executeTest("verifyNullaryResolvingToIntListCallback()")
+        executeTest("verifyNullaryResolvingToDoubleListCallback()")
+        executeTest("verifyNullaryResolvingToStructListCallback()")
+        executeTest("verifyNullaryResolvingToIntArrayCallback()")
+        executeTest("verifyNullaryResolvingToStringStringMapCallback()")
+        executeTest("verifyNullaryResolvingToStringIntMapCallback()")
+        executeTest("verifyNullaryResolvingToStringDoubleMapCallback()")
+        executeTest("verifyNullaryResolvingToStringStructMapCallback()")
+        executeTest("verifyNullaryResolvingToStringIntCallback()")
+        executeTest("verifyNullaryResolvingToIntStructCallback()")
+        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
+        executeTest("verifyUnaryIntResolvingToIntCallback()")
+        executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
+    }
+}

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -1,13 +1,13 @@
 //
-//  SharedTestsWebView.swift
-//  NimbusTests
-//
-//  Created by Paul Tiarks on 5/19/20.
-//  Copyright © 2020 Salesforce.com, inc. All rights reserved.
+// Copyright (c) 2020, Salesforce.com, inc.
+// All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// For full license text, see the LICENSE file in the repo
+// root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-import XCTest
 import WebKit
+import XCTest
 @testable import Nimbus
 
 class SharedTestsWebView: XCTestCase {
@@ -30,7 +30,7 @@ class SharedTestsWebView: XCTestCase {
         bridge.addPlugin(testPlugin)
         bridge.attach(to: webView)
 
-        //load nimbus.js
+        // load nimbus.js
         if let jsURL = Bundle(for: SharedTestsWebView.self).url(forResource: "nimbus", withExtension: "js", subdirectory: "iife"),
             let jsString = try? String(contentsOf: jsURL) {
             let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
@@ -39,7 +39,7 @@ class SharedTestsWebView: XCTestCase {
             XCTFail("couldn't get nimbus js")
         }
 
-        //load shared-tests.js
+        // load shared-tests.js
         if let jsURL = Bundle(for: SharedTestsWebView.self).url(forResource: "shared-tests", withExtension: "js", subdirectory: "test-www"),
             let jsString = try? String(contentsOf: jsURL) {
             let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
@@ -69,7 +69,7 @@ class SharedTestsWebView: XCTestCase {
         XCTAssertTrue(expectPlugin.passed, "Failed: \(testName)")
     }
 
-    func testAllTests() { //swiftlint:disable:this function_body_length
+    func testAllTests() { // swiftlint:disable:this function_body_length
         executeTest("verifyNullaryResolvingToInt()")
         executeTest("verifyNullaryResolvingToDouble()")
         executeTest("verifyNullaryResolvingToDouble()")

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -36,7 +36,13 @@ class SharedTestsWebView: XCTestCase {
             let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             webView.configuration.userContentController.addUserScript(userScript)
         } else {
-            XCTFail("couldn't get nimbus js")
+            // when running from swiftpm, look for the file relative to the source root
+            let basepath = URL(fileURLWithPath: #file)
+            let url = URL(fileURLWithPath: "../../../../packages/nimbus-bridge/dist/iife/nimbus.js", relativeTo: basepath)
+            if FileManager().fileExists(atPath: url.absoluteURL.path), let script = try? String(contentsOf: url) {
+                let userScript = WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+                webView.configuration.userContentController.addUserScript(userScript)
+            }
         }
 
         // load shared-tests.js
@@ -45,14 +51,22 @@ class SharedTestsWebView: XCTestCase {
             let userScript = WKUserScript(source: jsString, injectionTime: .atDocumentStart, forMainFrameOnly: false)
             webView.configuration.userContentController.addUserScript(userScript)
         } else {
-            XCTFail("couldn't get test js")
+            // when running from swiftpm, look for the file relative to the source root
+            let basepath = URL(fileURLWithPath: #file)
+            let url = URL(fileURLWithPath: "../../../../packages/test-www/dist/test-www/shared-tests.js", relativeTo: basepath)
+            if FileManager().fileExists(atPath: url.absoluteURL.path), let script = try? String(contentsOf: url) {
+                let userScript = WKUserScript(source: script, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+                webView.configuration.userContentController.addUserScript(userScript)
+            }
         }
 
         // load the html
         if let htmlURL = Bundle(for: SharedTestsWebView.self).url(forResource: "shared-tests", withExtension: "html", subdirectory: "test-www") {
             webView.loadFileURL(htmlURL, allowingReadAccessTo: htmlURL)
         } else {
-            XCTFail("couldn't get the test html")
+            let basepath = URL(fileURLWithPath: #file)
+            let url = URL(fileURLWithPath: "../../../../packages/test-www/dist/test-www/shared-tests.html", relativeTo: basepath)
+            webView.loadFileURL(url, allowingReadAccessTo: url)
         }
 
         wait(for: [readyExpectation], timeout: 60)

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -66,7 +66,7 @@ class SharedTestsWebView: XCTestCase {
         webView.evaluateJavaScript(testName, completionHandler: nil)
         waitForExpectations(timeout: 1, handler: nil)
         XCTAssertTrue(expectPlugin.isFinished)
-        XCTAssertTrue(expectPlugin.passed)
+        XCTAssertTrue(expectPlugin.passed, "Failed: \(testName)")
     }
 
     func testAllTests() { //swiftlint:disable:this function_body_length
@@ -110,7 +110,7 @@ class SharedTestsWebView: XCTestCase {
         executeTest("verifyNullaryResolvingToStringStructMapCallback()")
         executeTest("verifyNullaryResolvingToStringIntCallback()")
         executeTest("verifyNullaryResolvingToIntStructCallback()")
-        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
+//        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
         executeTest("verifyUnaryIntResolvingToIntCallback()")
         executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
     }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -110,7 +110,6 @@ class SharedTestsWebView: XCTestCase {
         executeTest("verifyNullaryResolvingToStringStructMapCallback()")
         executeTest("verifyNullaryResolvingToStringIntCallback()")
         executeTest("verifyNullaryResolvingToIntStructCallback()")
-//        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
         executeTest("verifyUnaryIntResolvingToIntCallback()")
         executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
     }


### PR DESCRIPTION
This adds the tests added on Android intended to be shared by both platforms to iOS. They are executing in both the webview and JSCore contexts.

One discrepancy is with a test that has a callback with 3 parameters. We don't currently support more than 2 parameters to a callback on iOS, with the intent being there would be a parameter for the result and a parameter for an error. @mattkranzler5 I think we may want to bring Android in line with iOS and find some way to limit Android to only 2 parameters as well. Do you have any thoughts on that?