### PR TITLE
Now limiting callbacks to two parameters, fixed bug in demo app

### DIFF
--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -480,19 +480,6 @@ function verifyNullaryResolvingToIntStructCallback() {
   }).then(() => {});
 }
 
-function verifyNullaryResolvingToDoubleIntStructCallback() {
-  __nimbus.plugins.testPlugin.nullaryResolvingToIntDoubleStructCallback((int, double, struct) => {
-    if (int === 3 &&
-      double === 4.0 &&
-      struct.string === 'String' &&
-      struct.integer === 1 &&
-      struct.double === 2.0) {
-      __nimbus.plugins.expectPlugin.pass();
-    }
-    __nimbus.plugins.expectPlugin.finished();
-  }).then(() => {});
-}
-
 function verifyUnaryIntResolvingToIntCallback() {
   __nimbus.plugins.testPlugin.unaryIntResolvingToIntCallback(3, (result) => {
     if (result === 4) {

--- a/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -351,6 +351,12 @@ class V8BinderGenerator : BinderGenerator() {
         parameterIndex: Int
     ): CodeBlock {
 
+        // Check if there are more than two parameters in callback. Only two parameters (result, error) are allowed.
+        if (declaredType.typeArguments.size > 3) { // one type is for the return type (should be void)
+            error(parameter, "Only two parameters are allowed in callbacks.")
+            return CodeBlock.of("")
+        }
+
         // try to get the parameter type from the kotlin class
         // metadata to determine if it is nullable
         val kotlinParameterType = kotlinParameter?.type

--- a/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -36,7 +36,6 @@ class WebViewBinderGenerator : BinderGenerator() {
     private val jsonSerializationConfigurationClassName = ClassName("kotlinx.serialization.json", "JsonConfiguration")
 
     private val jsonObjectClassName = ClassName("org.json", "JSONObject")
-    private val jsonArrayClassName = ClassName("org.json", "JSONArray")
 
     private val toJSONEncodableFunctionName = ClassName(nimbusPackage, "toJSONEncodable")
     private val kotlinJSONEncodableClassName = ClassName(nimbusPackage, "KotlinJSONEncodable")
@@ -252,6 +251,12 @@ class WebViewBinderGenerator : BinderGenerator() {
         kotlinParameter: KmValueParameter?,
         funSpec: FunSpec.Builder
     ) {
+
+        // Check if there are more than two parameters in callback. Only two parameters (result, error) are allowed.
+        if (declaredType.typeArguments.size > 3) { // one type is for the return type (should be void)
+            error(parameter, "Only two parameters are allowed in callbacks.")
+            return
+        }
 
         // try to get the parameter type from the kotlin class
         // metadata to determine if it is nullable

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -14,6 +14,7 @@ import android.webkit.WebView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.eclipsesource.v8.V8
+import com.salesforce.k2v8.scope
 import com.salesforce.nimbus.BoundMethod
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
@@ -63,15 +64,17 @@ class MainActivity : AppCompatActivity() {
         }
 
         // execute a script to get the device info plugin and then log to the console
-        v8.executeScript(
-            """
-            __nimbus.plugins.DeviceInfoPlugin.getDeviceInfo().then((deviceInfo) => {
-                let json = JSON.stringify(deviceInfo);
-                __nimbus.plugins.LogPlugin.debug('DemoApp', json);
-                __nimbus.plugins.ToastPlugin.toast('Device Info from V8: ' + json);
-            });
-            """.trimIndent()
-        )
+        v8.scope {
+            v8.executeScript(
+                """
+                    __nimbus.plugins.DeviceInfoPlugin.getDeviceInfo().then((deviceInfo) => {
+                        let json = JSON.stringify(deviceInfo);
+                        __nimbus.plugins.LogPlugin.debug('DemoApp', json);
+                        __nimbus.plugins.ToastPlugin.toast('Device Info from V8: ' + json);
+                    });
+                """.trimIndent()
+            )
+        }
     }
 
     override fun onDestroy() {

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -272,11 +272,6 @@ class TestPlugin : Plugin {
     }
 
     @BoundMethod
-    fun nullaryResolvingToIntDoubleStructCallback(callback: (Int, Double, TestStruct) -> Unit) {
-        callback(3, 4.0, TestStruct())
-    }
-
-    @BoundMethod
     fun unaryIntResolvingToIntCallback(param: Int, callback: (Int) -> Unit) {
         callback(param + 1)
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -263,11 +263,6 @@ class V8PluginTests {
     }
 
     @Test
-    fun verifyNullaryResolvingToDoubleIntStructCallback() {
-        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
-    }
-
-    @Test
     fun verifyUnaryIntResolvingToIntCallback() {
         executeTest("verifyUnaryIntResolvingToIntCallback()")
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -324,11 +324,6 @@ class WebViewPluginTests {
     }
 
     @Test
-    fun verifyNullaryResolvingToDoubleIntStructCallback() {
-        executeTest("verifyNullaryResolvingToDoubleIntStructCallback()")
-    }
-
-    @Test
     fun verifyUnaryIntResolvingToIntCallback() {
         executeTest("verifyUnaryIntResolvingToIntCallback()")
     }


### PR DESCRIPTION
This PR limits the amount of parameters in a function callback to 2. This brings Android in line with iOS in this respect. The intent is that one parameter is meant for the callback result and the other is the callback error. 