### PR TITLE
Fix for custom serializer, added date serialization to shared tests 

### DIFF
--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -45,6 +45,21 @@ function verifyNullaryResolvingToStruct() {
   });
 }
 
+function verifyNullaryResolvingToDateWrapper() {
+  __nimbus.plugins.testPlugin.nullaryResolvingToDateWrapper().then((result) => {
+    let date = new Date(result.date);
+    if (date.getFullYear() === 2020 &&
+      date.getMonth() === 5 && // month is 0 indexed
+      date.getDate() === 4 &&
+      date.getHours() === 12 &&
+      date.getMinutes() === 24 &&
+      date.getSeconds() === 48) {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
 function verifyNullaryResolvingToIntList() {
   __nimbus.plugins.testPlugin.nullaryResolvingToIntList().then((result) => {
     if (result[0] === 1 &&
@@ -203,6 +218,18 @@ function verifyUnaryStructResolvingToJsonString() {
   });
 }
 
+function verifyUnaryDateWrapperResolvingToJsonString() {
+  __nimbus.plugins.testPlugin.unaryDateWrapperResolvingToJsonString({
+    "date": "2020-06-04T03:02:01.000+0000"
+  }).then((result) => {
+    let json = JSON.parse(result);
+    if (json['date'] === '2020-06-05T03:02:01.000+0000') {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
 function verifyUnaryStringListResolvingToString() {
   __nimbus.plugins.testPlugin.unaryStringListResolvingToString(['1','2','3']).then((result) => {
     if (result === '1, 2, 3') {
@@ -343,6 +370,21 @@ function verifyNullaryResolvingToStructCallback() {
     if (result.string === 'String' &&
       result.integer === 1 &&
       result.double === 2.0) {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  }).then(() => {});
+}
+
+function verifyNullaryResolvingToDateWrapperCallback() {
+  __nimbus.plugins.testPlugin.nullaryResolvingToDateWrapperCallback((result) => {
+    let date = new Date(result.date);
+    if (date.getFullYear() === 2020 &&
+      date.getMonth() === 5 && // month is 0 indexed
+      date.getDate() === 4 &&
+      date.getHours() === 0 &&
+      date.getMinutes() === 0 &&
+      date.getSeconds() === 0) {
       __nimbus.plugins.expectPlugin.pass();
     }
     __nimbus.plugins.expectPlugin.finished();

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -85,6 +85,11 @@ abstract class BinderGenerator : AbstractProcessor() {
             // get all serializable elements
             serializableElements = env.getElementsAnnotatedWith(Serializable::class.java)
 
+                // Filter out any non-declared types (such as properties/methods annotated). This is necessary
+                // when a Serializable class has a property annotated @Serializable with a custom serializer.
+                .filter { it.asType().kind == TypeKind.DECLARED }
+                .toSet()
+
             // find any duplicate plugin names
             val duplicates =
                 pluginElements.groupingBy { it.getAnnotation(PluginOptions::class.java).name }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -1,11 +1,27 @@
 package com.salesforce.nimbus.bridge.tests.plugin
 
+import com.salesforce.k2v8.V8ObjectDecoder
+import com.salesforce.k2v8.V8ObjectEncoder
 import com.salesforce.nimbus.BoundMethod
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
+import kotlinx.serialization.Decoder
+import kotlinx.serialization.Encoder
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.PrimitiveDescriptor
+import kotlinx.serialization.PrimitiveKind
+import kotlinx.serialization.SerialDescriptor
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.Serializer
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonConfiguration
+import kotlinx.serialization.json.JsonInput
+import kotlinx.serialization.json.JsonOutput
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.TimeZone
 
 @Serializable
 data class TestStruct(
@@ -15,6 +31,33 @@ data class TestStruct(
 ) {
     override fun toString(): String {
         return "$string, $integer, $double"
+    }
+}
+
+@Serializable
+data class DateWrapper(
+    @Serializable(with = DateSerializer::class) val date: Date = Date()
+)
+
+@Serializer(forClass = Date::class)
+object DateSerializer : KSerializer<Date> {
+    override val descriptor: SerialDescriptor = PrimitiveDescriptor("java.util.Date", PrimitiveKind.STRING)
+
+    private val dateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
+        .apply { timeZone = TimeZone.getTimeZone("UTC") }
+
+    override fun serialize(encoder: Encoder, value: Date) {
+        when (encoder) {
+            is V8ObjectEncoder, is JsonOutput -> encoder.encodeString(dateFormat.format(value))
+            else -> throw SerializationException("Unknown encoder type")
+        }
+    }
+
+    override fun deserialize(decoder: Decoder): Date {
+        return when (decoder) {
+            is V8ObjectDecoder, is JsonInput -> dateFormat.parse(decoder.decodeString())
+            else -> throw SerializationException("Unknown decoder type")
+        }
     }
 }
 
@@ -41,6 +84,13 @@ class TestPlugin : Plugin {
     @BoundMethod
     fun nullaryResolvingToStruct(): TestStruct {
         return TestStruct()
+    }
+
+    @BoundMethod
+    fun nullaryResolvingToDateWrapper(): DateWrapper {
+        return DateWrapper(Calendar.getInstance().apply {
+            set(2020, 5, 4, 12, 24, 48)
+        }.time)
     }
 
     @BoundMethod
@@ -121,6 +171,15 @@ class TestPlugin : Plugin {
     }
 
     @BoundMethod
+    fun unaryDateWrapperResolvingToJsonString(param: DateWrapper): String {
+        return Json(JsonConfiguration.Stable).stringify(DateWrapper.serializer(),
+            param.copy(date = Calendar.getInstance().apply {
+                time = param.date
+                add(Calendar.DAY_OF_YEAR, 1)
+            }.time))
+    }
+
+    @BoundMethod
     fun unaryStringListResolvingToString(param: List<String>): String {
         return param.joinToString(separator = ", ")
     }
@@ -184,6 +243,15 @@ class TestPlugin : Plugin {
     @BoundMethod
     fun nullaryResolvingToStructCallback(callback: (TestStruct) -> Unit) {
         callback(TestStruct())
+    }
+
+    @BoundMethod
+    fun nullaryResolvingToDateWrapperCallback(callback: (DateWrapper) -> Unit) {
+        callback(
+            DateWrapper(Calendar.getInstance().apply {
+                set(2020, 5, 4, 0, 0, 0)
+            }.time)
+        )
     }
 
     @BoundMethod

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -75,6 +75,11 @@ class V8PluginTests {
     }
 
     @Test
+    fun verifyNullaryResolvingToDateWrapper() {
+        executeTest("verifyNullaryResolvingToDateWrapper()")
+    }
+
+    @Test
     fun verifyNullaryResolvingToIntList() {
         executeTest("verifyNullaryResolvingToIntList()")
     }
@@ -144,6 +149,11 @@ class V8PluginTests {
     }
 
     @Test
+    fun verifyUnaryDateWrapperResolvingToJsonString() {
+        executeTest("verifyUnaryDateWrapperResolvingToJsonString()")
+    }
+
+    @Test
     fun verifyUnaryStringListResolvingToString() {
         executeTest("verifyUnaryStringListResolvingToString()")
     }
@@ -205,6 +215,11 @@ class V8PluginTests {
     @Test
     fun verifyNullaryResolvingToStructCallback() {
         executeTest("verifyNullaryResolvingToStructCallback()")
+    }
+
+    @Test
+    fun verifyNullaryResolvingToDateWrapperCallback() {
+        executeTest("verifyNullaryResolvingToDateWrapperCallback()")
     }
 
     @Test

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -136,6 +136,11 @@ class WebViewPluginTests {
     }
 
     @Test
+    fun verifyNullaryResolvingToDateWrapper() {
+        executeTest("verifyNullaryResolvingToDateWrapper()")
+    }
+
+    @Test
     fun verifyNullaryResolvingToIntList() {
         executeTest("verifyNullaryResolvingToIntList()")
     }
@@ -205,6 +210,11 @@ class WebViewPluginTests {
     }
 
     @Test
+    fun verifyUnaryDateWrapperResolvingToJsonString() {
+        executeTest("verifyUnaryDateWrapperResolvingToJsonString()")
+    }
+
+    @Test
     fun verifyUnaryStringListResolvingToString() {
         executeTest("verifyUnaryStringListResolvingToString()")
     }
@@ -266,6 +276,11 @@ class WebViewPluginTests {
     @Test
     fun verifyNullaryResolvingToStructCallback() {
         executeTest("verifyNullaryResolvingToStructCallback()")
+    }
+
+    @Test
+    fun verifyNullaryResolvingToDateWrapperCallback() {
+        executeTest("verifyNullaryResolvingToDateWrapperCallback()")
     }
 
     @Test


### PR DESCRIPTION
This PR adds a custom date serializer and some shared tests to the `shared-tests` module to verify custom serializers work properly with JSON & K2V8 serializers.