### PR TITLE
add auto test for android bound method return

### DIFF
--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -113,59 +113,63 @@ describe("Callbacks with", () => {
   });
   // commented out until supported by android
   // tests work on iOS but fail on android
-  // it('should return a promise string and the callback should have an object', done => {
-  //   nimbusWithCallbackTestPlugin.callbackTestPlugin.callbackWithSingleParamAndReturn(
-  //     (param0: MochaMessage) => {
-  //       expect(param0).to.deep.equal({
-  //         intField: 42,
-  //         stringField: "This is a string"
-  //       });
-  //     }
-  //   ).then((result: string) => {
-  //     expect(result).to.equal("one");
-  //     done();
-  //   });
-  // });
+  it("should return a promise string and the callback should have an object", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .callbackWithSingleParamAndReturn((param0: MochaMessage) => {
+        expect(param0).to.deep.equal({
+          intField: 42,
+          stringField: "This is a string",
+        });
+      })
+      .then((result: string) => {
+        expect(result).to.equal("one");
+        done();
+      });
+  });
 
-  // it('should return a promise string and the callback should have an int', done => {
-  //   nimbusWithCallbackTestPlugin.callbackTestPlugin.callbackWithSinglePrimitiveParamAndReturn(
-  //     (param0: number) => {
-  //       expect(param0).to.equal(1);
-  //     }
-  //   ).then((result: string) => {
-  //     expect(result).to.equal("one");
-  //     done();
-  //   });
-  // });
+  it("should return a promise string and the callback should have an int", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .callbackWithSinglePrimitiveParamAndReturn((param0: number) => {
+        expect(param0).to.equal(1);
+      })
+      .then((result: string) => {
+        expect(result).to.equal("one");
+        done();
+      });
+  });
 
-  // it('should return a promise string and the callback should have two objects', done => {
-  //   nimbusWithCallbackTestPlugin.callbackTestPlugin.callbackWithTwoParamAndReturn(
-  //     (param0: MochaMessage, param1: MochaMessage) => {
-  //       expect(param0).to.deep.equal({
-  //         intField: 42,
-  //         stringField: "This is a string"
-  //       });
+  it("should return a promise string and the callback should have two objects", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .callbackWithTwoParamAndReturn(
+        (param0: MochaMessage, param1: MochaMessage) => {
+          expect(param0).to.deep.equal({
+            intField: 42,
+            stringField: "This is a string",
+          });
 
-  //       expect(param1).to.deep.equal({
-  //         intField: 3,
-  //         stringField: "mock"
-  //       });
-  //     }
-  //   ).then((result: string) => {
-  //     expect(result).to.equal("two");
-  //     done();
-  //   });
-  // });
+          expect(param1).to.deep.equal({
+            intField: 3,
+            stringField: "mock",
+          });
+        }
+      )
+      .then((result: string) => {
+        expect(result).to.equal("two");
+        done();
+      });
+  });
 
-  // it('should return a promise string and the callback should have two ints', done => {
-  //   nimbusWithCallbackTestPlugin.callbackTestPlugin.callbackWithTwoPrimitiveParamAndReturn(
-  //     (param0: number, param1: number) => {
-  //       expect(param0).to.equal(1);
-  //       expect(param1).to.equal(2);
-  //     }
-  //   ).then((result: string) => {
-  //     expect(result).to.equal("two");
-  //     done();
-  //   });
-  // });
+  it("should return a promise string and the callback should have two ints", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .callbackWithTwoPrimitiveParamAndReturn(
+        (param0: number, param1: number) => {
+          expect(param0).to.equal(1);
+          expect(param1).to.equal(2);
+        }
+      )
+      .then((result: string) => {
+        expect(result).to.equal("two");
+        done();
+      });
+  });
 });

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestPlugin.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestPlugin.kt
@@ -100,4 +100,29 @@ class CallbackTestPlugin : Plugin {
         jo1.put("six", 6)
         arg(jo0, jo1)
     }
+
+    @BoundMethod
+    fun callbackWithSingleParamAndReturn(arg: (param0: MochaTests.MochaMessage) -> Unit): String {
+        arg(MochaTests.MochaMessage())
+        return "one"
+    }
+
+    @BoundMethod
+    fun callbackWithSinglePrimitiveParamAndReturn(arg: (param0: Int) -> Unit): String {
+        arg(777)
+        return "one"
+    }
+
+    @BoundMethod
+    fun callbackWithTwoParamAndReturn(arg: (param0: MochaTests.MochaMessage, param1: MochaTests.MochaMessage) -> Unit): String {
+        var mochaMessage = MochaTests.MochaMessage("mock", 3)
+        arg(MochaTests.MochaMessage(), mochaMessage)
+        return "two"
+    }
+
+    @BoundMethod
+    fun callbackWithTwoPrimitiveParamAndReturn(arg: (param0: Int, param1: Int) -> Unit): String {
+        arg(1, 2)
+        return "two"
+    }
 }


### PR DESCRIPTION
Extend the android callback test plugin to support nimbus tests for bound method return value as promise 