### PR TITLE
Allow disabling binder generation

### DIFF
--- a/platforms/android/annotations/src/main/java/com/salesforce/nimbus/PluginOptions.kt
+++ b/platforms/android/annotations/src/main/java/com/salesforce/nimbus/PluginOptions.kt
@@ -2,4 +2,18 @@ package com.salesforce.nimbus
 
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
-annotation class PluginOptions(val name: String)
+annotation class PluginOptions(
+    val name: String,
+
+    /**
+     * Whether or not this plugin supports binding to a WebView. If true, a binder will be generated
+     * for the WebView. Defaults to true.
+     */
+    val supportsWebView: Boolean = true,
+
+    /**
+     * Whether or not this plugin supports binding to V8. If true, a binder will be generated
+     * for V8. Defaults to true.
+     */
+    val supportsV8: Boolean = true
+)

--- a/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -113,7 +113,7 @@ abstract class BinderGenerator : AbstractProcessor() {
                             pluginElement,
                             "${PluginOptions::class.java.simpleName} class must extend $nimbusPackage.Plugin."
                         )
-                    } else {
+                    } else if (shouldGenerateBinder(pluginElement)) {
 
                         // process each plugin element to create a type spec
                         val binderTypeSpec = processPluginElement(pluginElement, serializableElements)
@@ -316,6 +316,10 @@ abstract class BinderGenerator : AbstractProcessor() {
     protected open fun processUnbindFunction(builder: FunSpec.Builder) {
         /* leave for subclasses to override */
     }
+
+    abstract fun shouldGenerateBinder(
+        pluginElement: Element
+    ): Boolean
 
     abstract fun createBinderExtensionFunction(
         pluginElement: Element,

--- a/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -1,5 +1,6 @@
 package com.salesforce.nimbus.bridge.v8.compiler
 
+import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.compiler.BinderGenerator
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
@@ -39,6 +40,10 @@ class V8BinderGenerator : BinderGenerator() {
     private val v8ArrayClassName = ClassName(v8Package, "V8Array")
     private val v8FunctionClassName = ClassName(v8Package, "V8Function")
     private val k2V8ClassName = ClassName(k2v8Package, "K2V8")
+
+    override fun shouldGenerateBinder(pluginElement: Element): Boolean {
+        return pluginElement.getAnnotation(PluginOptions::class.java).supportsV8
+    }
 
     override fun processClassProperties(builder: TypeSpec.Builder) {
 

--- a/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -1,5 +1,6 @@
 package com.salesforce.nimbus.bridge.webview.compiler
 
+import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.compiler.BinderGenerator
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
@@ -39,6 +40,10 @@ class WebViewBinderGenerator : BinderGenerator() {
 
     private val toJSONEncodableFunctionName = ClassName(nimbusPackage, "toJSONEncodable")
     private val kotlinJSONEncodableClassName = ClassName(nimbusPackage, "KotlinJSONEncodable")
+
+    override fun shouldGenerateBinder(pluginElement: Element): Boolean {
+        return pluginElement.getAnnotation(PluginOptions::class.java).supportsWebView
+    }
 
     override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {
         return FunSpec.builder("webViewBinder")


### PR DESCRIPTION
Added a couple flags to `PluginOptions` to support disabling binder generation for each type. Here is an example if you would like to disable generating a V8Binder for a plugin:
```
@PluginOptions(name="MyPlugin", supportsV8=false)
```
Since V8 binders require Kotlin Serializable support this can be useful if a project pulls in a dependency that transitively uses `bridge-v8` but the project doesn't support Kotlin Serializable and still uses `JSONEncodable` to encode/decode to/from a webview. In this case they can disable V8 binders for their plugins so their won't be any compiler errors.