### PR TITLE
Now supporting non-void return values for functions that take a callback

### DIFF
--- a/packages/test-www/test/nimbus-core-tests.ts
+++ b/packages/test-www/test/nimbus-core-tests.ts
@@ -6,7 +6,7 @@
 //
 
 import "mocha";
-import { expect } from "chai";
+import {expect} from "chai";
 import nimbus from "nimbus-types";
 
 interface JSAPITestStruct {
@@ -125,18 +125,18 @@ describe("Nimbus JS API", () => {
   });
 
   // commented out test because they fail in android as it is not supported yet
-  // it('binary function accepting int and callback taking an object returning an int', (done) => {
-  //   __nimbus.plugins.jsapiTestPlugin.binaryResolvingToObjectCallbackToInt(
-  //     5,
-  //     (result: JSAPITestStruct) => {
-  //       expect(result).to.deep.equal({
-  //         intField: 42,
-  //         stringField: "JSAPITEST"
-  //       });
-  //     }
-  //   ).then((value: number) => {
-  //     expect(value).to.deep.equal(1);
-  //     done();
-  //   })
-  // });
+  it('binary function accepting int and callback taking an object returning an int', (done) => {
+    __nimbus.plugins.jsapiTestPlugin.binaryResolvingToObjectCallbackToInt(
+      5,
+      (result: JSAPITestStruct) => {
+        expect(result).to.deep.equal({
+          intField: 42,
+          stringField: "JSAPITEST"
+        });
+      }
+    ).then((value: number) => {
+      expect(value).to.deep.equal(1);
+      done();
+    })
+  });
 });

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -540,25 +540,24 @@ function verifyBinaryIntDoubleResolvingToIntDoubleCallback() {
   }).then(() => {});
 }
 
-// comment out unsupported test for android
-// function verifyBinaryIntResolvingIntCallbackReturnsInt() {
-//   let count = 0;
-//   const verifyCallbacks = () => {
-//     count = count + 1;
-//     if (count === 2) {
-//       __nimbus.plugins.expectPlugin.pass();
-//       __nimbus.plugins.expectPlugin.finished();
-//     }
-//   }
-//   __nimbus.plugins.testPlugin.binaryIntResolvingIntCallbackReturnsInt(3, (int) => {
-//     if (int === 2) {
-//       verifyCallbacks();
-//     }
-//   }).then((result) =>{
-//     if (result === 1) {
-//       verifyCallbacks();
-//     }
-//   });
-// }
+function verifyBinaryIntResolvingIntCallbackReturnsInt() {
+  let count = 0;
+  const verifyCallbacks = () => {
+    count = count + 1;
+    if (count === 2) {
+      __nimbus.plugins.expectPlugin.pass();
+      __nimbus.plugins.expectPlugin.finished();
+    }
+  }
+  __nimbus.plugins.testPlugin.binaryIntResolvingIntCallbackReturnsInt(3, (int) => {
+    if (int === 2) {
+      verifyCallbacks();
+    }
+  }).then((result) =>{
+    if (result === 1) {
+      verifyCallbacks();
+    }
+  });
+}
 
 // endregion

--- a/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -146,7 +146,6 @@ class V8BinderGenerator : BinderGenerator() {
         kotlinFunction: KmFunction?
     ): FunSpec {
         val functionName = functionElement.simpleName.toString()
-        val functionReturnType = functionElement.returnType
 
         // create the binder function
         val parameters = "parameters"
@@ -196,15 +195,6 @@ class V8BinderGenerator : BinderGenerator() {
                                     error(
                                         functionElement,
                                         "Only a Unit (Void) return type in callbacks is supported."
-                                    )
-                                    return@forEachIndexed
-                                }
-
-                                // throw a compiler error if the function does not return void
-                                !functionReturnType.isUnitType() -> {
-                                    error(
-                                        functionElement,
-                                        "Functions with a callback only support a Unit (Void) return type."
                                     )
                                     return@forEachIndexed
                                 }

--- a/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -57,7 +57,6 @@ class WebViewBinderGenerator : BinderGenerator() {
         kotlinFunction: KmFunction?
     ): FunSpec {
         val functionName = functionElement.simpleName.toString()
-        val functionReturnType = functionElement.returnType
 
         // try to find the fun from the kotlin class metadata to see if the
         // return type is nullable
@@ -98,12 +97,6 @@ class WebViewBinderGenerator : BinderGenerator() {
                                 !functionParameterReturnType.isUnitType() -> error(
                                     functionElement,
                                     "Only a Unit (Void) return type in callbacks is supported."
-                                )
-
-                                // throw a compiler error if the function does not return void
-                                !functionReturnType.isUnitType() -> error(
-                                    functionElement,
-                                    "Functions with a callback only support a Unit (Void) return type."
                                 )
                                 else -> processFunctionParameter(
                                     declaredType,
@@ -197,7 +190,7 @@ class WebViewBinderGenerator : BinderGenerator() {
                 funSpec.addStatement(
                     "return target.%N($argsString)",
                     functionElement.simpleName.toString()
-                )
+                ).returns(returnType.asKotlinTypeName())
             }
         }
 

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -348,4 +348,10 @@ class TestPlugin : Plugin {
     fun binaryIntDoubleResolvingToIntDoubleCallback(param0: Int, param1: Double, callback: (Int, Double) -> Unit) {
         callback(param0 + 1, param1 * 2)
     }
+
+    @BoundMethod
+    fun binaryIntResolvingIntCallbackReturnsInt(param0: Int, callback: (Int) -> Unit): Int {
+        callback(param0 - 1)
+        return param0 - 2
+    }
 }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -287,6 +287,11 @@ class V8PluginTests {
         executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
     }
 
+    @Test
+    fun verifyBinaryIntResolvingIntCallbackReturnsInt() {
+        executeTest("verifyBinaryIntResolvingIntCallbackReturnsInt()")
+    }
+
     // endregion
 
     private fun executeTest(function: String) {

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
@@ -165,4 +165,11 @@ class JSAPITestPlugin : Plugin {
         assertEquals(param0, 5)
         param1(JSAPITestStruct())
     }
+
+    @BoundMethod
+    fun binaryResolvingToObjectCallbackToInt(param0: Int, param1: (result: JSAPITestStruct) -> Unit): Int {
+        assertEquals(param0, 5)
+        param1(JSAPITestStruct())
+        return 1
+    }
 }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -348,6 +348,11 @@ class WebViewPluginTests {
         executeTest("verifyBinaryIntDoubleResolvingToIntDoubleCallback()")
     }
 
+    @Test
+    fun verifyBinaryIntResolvingIntCallbackReturnsInt() {
+        executeTest("verifyBinaryIntResolvingIntCallbackReturnsInt()")
+    }
+
     // endregion
 
     private fun executeTest(script: String) {


### PR DESCRIPTION
This PR makes the change that was already made in iOS to support a return value from bound methods that take a callback as a parameter. This was a compiler error previously.