### PR TITLE
Promise rejection fix

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -136,13 +136,17 @@ let promisify = (src: any): void => {
   let dest: any = {};
   Object.keys(src).forEach((key): void => {
     let func = src[key];
-    dest[key] = (...args: any[]): any => {
+    dest[key] = (...args: any[]): Promise<any> => {
       args = cloneArguments(args);
-      let result = func.call(src, ...args);
-      if (result !== undefined) {
-        result = JSON.parse(result);
+      try {
+        let result = func.call(src, ...args);
+        if (result !== undefined) {
+          result = JSON.parse(result);
+        }
+        return Promise.resolve(result);
+      } catch (error) {
+        return Promise.reject(error);
       }
-      return Promise.resolve(result);
     };
   });
   return dest;

--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -162,7 +162,7 @@ let releaseCallback = (callbackId: string): void => {
 // in the storage
 let resolvePromise = (promiseUuid: string, data: any, error: any): void => {
   if (error) {
-    uuidsToPromises[promiseUuid].reject(data);
+    uuidsToPromises[promiseUuid].reject(error);
   } else {
     uuidsToPromises[promiseUuid].resolve(data);
   }

--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -13,11 +13,6 @@ interface MochaMessage {
   stringField: string;
 }
 
-interface TestError {
-  code: number;
-  message: string;
-}
-
 interface CallbackTestPlugin {
   callbackWithSingleParam(completion: (param0: MochaMessage) => void): void;
   callbackWithTwoParams(
@@ -182,28 +177,19 @@ describe("Callbacks with", () => {
   });
 
   it("promise resolves and passes the value", (done) => {
-    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseResolved()
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .promiseResolved()
       .then((result: string) => {
-        expect(result).to.equal("promise")
-        done();
-      });
-  });
-
-  it("promise rejects and passes encoded error", (done) => {
-    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseRejectedEncoded()
-      .catch((error: TestError) => {
-        expect(error).to.deep.equal({
-          code: 42,
-          message: "mock promise rejection"
-        });
+        expect(result).to.equal("promise");
         done();
       });
   });
 
   it("promise rejects and passes the error", (done) => {
-    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseRejected()
-      .catch((error) => {
-        expect(error).to.equal("rejectedError")
+    nimbusWithCallbackTestPlugin.callbackTestPlugin
+      .promiseRejected()
+      .then((_) => done("unexpected completion"))
+      .catch((_) => {
         done();
       });
   });

--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -13,6 +13,11 @@ interface MochaMessage {
   stringField: string;
 }
 
+interface TestError {
+  code: number;
+  message: string;
+}
+
 interface CallbackTestPlugin {
   callbackWithSingleParam(completion: (param0: MochaMessage) => void): void;
   callbackWithTwoParams(
@@ -37,6 +42,9 @@ interface CallbackTestPlugin {
   callbackWithTwoPrimitiveParamAndReturn(
     completion: (param0: number, param1: number) => void
   ): Promise<string>;
+  promiseResolved(): Promise<string>;
+  promiseRejected(): Promise<string>;
+  promiseRejectedEncoded(): Promise<string>;
 }
 
 declare interface NimbusWithCallbackTestPlugin {
@@ -169,6 +177,33 @@ describe("Callbacks with", () => {
       )
       .then((result: string) => {
         expect(result).to.equal("two");
+        done();
+      });
+  });
+
+  it("promise resolves and passes the value", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseResolved()
+      .then((result: string) => {
+        expect(result).to.equal("promise")
+        done();
+      });
+  });
+
+  it("promise rejects and passes encoded error", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseRejectedEncoded()
+      .catch((error: TestError) => {
+        expect(error).to.deep.equal({
+          code: 42,
+          message: "mock promise rejection"
+        });
+        done();
+      });
+  });
+
+  it("promise rejects and passes the error", (done) => {
+    nimbusWithCallbackTestPlugin.callbackTestPlugin.promiseRejected()
+      .catch((error) => {
+        expect(error).to.equal("rejectedError")
         done();
       });
   });

--- a/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestPlugin.kt
+++ b/platforms/android/nimbus/src/androidTest/java/com/salesforce/nimbus/CallbackTestPlugin.kt
@@ -2,6 +2,7 @@ package com.salesforce.nimbus
 
 import org.json.JSONArray
 import org.json.JSONObject
+import java.lang.Exception
 
 @PluginOptions(name = "callbackTestPlugin")
 class CallbackTestPlugin : Plugin {
@@ -124,5 +125,13 @@ class CallbackTestPlugin : Plugin {
     fun callbackWithTwoPrimitiveParamAndReturn(arg: (param0: Int, param1: Int) -> Unit): String {
         arg(1, 2)
         return "two"
+    }
+
+    @BoundMethod
+    fun promiseResolved(): String = "promise"
+
+    @BoundMethod
+    fun promiseRejected() {
+        throw Exception()
     }
 }

--- a/platforms/apple/Sources/Nimbus/Connection.swift
+++ b/platforms/apple/Sources/Nimbus/Connection.swift
@@ -148,7 +148,8 @@ public class Connection<C>: Binder {
                 let jsonString = String(data: data, encoding: .utf8) {
                 webView?.evaluateJavaScript("__nimbus.resolvePromise('\(promiseId)', undefined, \(jsonString).e);")
             } else {
-                fatalError("Unable to encode error object: \(error)")
+                //if unable to decode then send then fallthrough to default error message
+                fallthrough
             }
         default:
             webView?.evaluateJavaScript("__nimbus.resolvePromise('\(promiseId)', undefined, '\(error)');")

--- a/platforms/apple/Sources/Nimbus/EncodableValue.swift
+++ b/platforms/apple/Sources/Nimbus/EncodableValue.swift
@@ -14,12 +14,17 @@ import Foundation
  Once `JSONEncoder` supports encoding top-level fragments this can
  be removed.
  */
+
+public typealias EncodableError = Error & Encodable
+
 public enum EncodableValue: Encodable {
     case void
     case value(Encodable)
+    case error(EncodableError)
 
     enum Keys: String, CodingKey {
         case v // swiftlint:disable:this identifier_name
+        case e // swiftlint:disable:this identifier_name
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -30,6 +35,9 @@ public enum EncodableValue: Encodable {
         case .value(let value):
             let superContainer = container.superEncoder(forKey: .v)
             try value.encode(to: superContainer)
+        case .error(let error):
+            let superContainer = container.superEncoder(forKey: .e)
+            try error.encode(to: superContainer)
         }
     }
 }

--- a/platforms/apple/Sources/Nimbus/EncodableValue.swift
+++ b/platforms/apple/Sources/Nimbus/EncodableValue.swift
@@ -32,10 +32,10 @@ public enum EncodableValue: Encodable {
         switch self {
         case .void:
             try container.encodeNil(forKey: .v)
-        case .value(let value):
+        case let .value(value):
             let superContainer = container.superEncoder(forKey: .v)
             try value.encode(to: superContainer)
-        case .error(let error):
+        case let .error(error):
             let superContainer = container.superEncoder(forKey: .e)
             try error.encode(to: superContainer)
         }

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -98,6 +98,11 @@ class MochaTests: XCTestCase, WKNavigationDelegate {
     }
 }
 
+public struct TestError: Error, Encodable {
+    let code: Int
+    let message: String
+}
+
 public class CallbackTestPlugin {
     func callbackWithSingleParam(completion: @escaping (MochaTests.MochaMessage) -> Swift.Void) {
         let mochaMessage = MochaTests.MochaMessage()
@@ -138,6 +143,22 @@ public class CallbackTestPlugin {
         completion(1, 2)
         return "two"
     }
+
+    func promiseResolved() -> String {
+        return "promise"
+    }
+
+    func promiseRejectedEncoded() throws -> String {
+        throw TestError(code: 42, message: "mock promise rejection")
+    }
+
+    func promiseRejected() throws -> String {
+        throw MockError.rejectedError
+    }
+}
+
+enum MockError: Error {
+    case rejectedError
 }
 
 extension CallbackTestPlugin: Plugin {
@@ -152,5 +173,8 @@ extension CallbackTestPlugin: Plugin {
         connection.bind(CallbackTestPlugin.callbackWithSinglePrimitiveParamAndReturn, as: "callbackWithSinglePrimitiveParamAndReturn")
         connection.bind(CallbackTestPlugin.callbackWithTwoParamAndReturn, as: "callbackWithTwoParamAndReturn")
         connection.bind(CallbackTestPlugin.callbackWithTwoPrimitiveParamAndReturn, as: "callbackWithTwoPrimitiveParamAndReturn")
+        connection.bind(CallbackTestPlugin.promiseResolved, as: "promiseResolved")
+        connection.bind(CallbackTestPlugin.promiseRejectedEncoded, as: "promiseRejectedEncoded")
+        connection.bind(CallbackTestPlugin.promiseRejected, as: "promiseRejected")
     }
 }


### PR DESCRIPTION
Rejected promises were sending the `undefined` data of a failed resolve type.
Now sending the `error` instead.