### PR TITLE
Fix for passing a thrown error

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -162,7 +162,7 @@ let releaseCallback = (callbackId: string): void => {
 // in the storage
 let resolvePromise = (promiseUuid: string, data: any, error: any): void => {
   if (error) {
-    uuidsToPromises[promiseUuid].reject(data);
+    uuidsToPromises[promiseUuid].reject(error);
   } else {
     uuidsToPromises[promiseUuid].resolve(data);
   }


### PR DESCRIPTION
When throwing an error in iOS it always returned a string of `undefined` because it was returning the data of a resolved promise instead of the error of a rejected one.