### PR TITLE
Added an overload for the bind method.

### DIFF
--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -126,6 +126,14 @@ public protocol Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) where A0: Decodable
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<A0, A1, A2>(
         _ name: String,
         to function: @escaping (A0, A1, A2) throws -> Void
@@ -385,6 +393,16 @@ public extension Binder {
      */
     func bind<R: Encodable, A0, CB0: Encodable>(
         _ function: @escaping (A0, @escaping (CB0) -> Void) throws -> R,
+        as name: String
+    ) where A0: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
         as name: String
     ) where A0: Decodable {
         bind(name, to: function)

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -288,7 +288,7 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
-    func testBindTernaryWithTwoUnaryCallbackWithReturn() {
+    func testBindTernaryWithTwoUnaryCallbackWithReturnThrows() {
         binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
         let expecter0 = expectation(description: "callback0")
         let expecter1 = expectation(description: "callback0")

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -619,7 +619,7 @@ class BindTarget {
         callback1(arg0)
         return arg0
     }
-    
+
     func quaternaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) {
         called = true
     }

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -288,6 +288,28 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
+    func testBindTernaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "callback0")
+        let expecter1 = expectation(description: "callback0")
+        var result0: Int?
+        var result1: Int?
+        let callback0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let callback1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([42, callback0, callback1]) as? Int
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(value, .some(42))
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(42))
+    }
+
     func testBindQuaternaryNoReturn() {
         binder.bind(binder.target.quaternaryNoReturn, as: "")
         _ = try? binder.callable([42, 37, 13, 7])
@@ -591,6 +613,13 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func ternaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) -> Int {
+        called = true
+        callback0(arg0)
+        callback1(arg0)
+        return arg0
+    }
+    
     func quaternaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) {
         called = true
     }


### PR DESCRIPTION
Added one overload for the `bind` method. This overload is unique in that it takes a second callback. I am purposely omitting adding derivations of this overload because the use case of it is very limited for now. Should there be more use cases in the future that can take advantage of there being a second callback, then, overloading more `bind` methods should be revisited at that time. Android already supports the second callback via its `@BoundMethod` annotation.