### PR TITLE
Added overloads for the bind method.

### DIFF
--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -70,17 +70,17 @@ public protocol Binder {
     /**
      Bind the specified function to this connection.
      */
-    func bind<CB0: Encodable, CB1: Encodable>(
+    func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
         _ name: String,
-        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+        to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
     )
 
     /**
      Bind the specified function to this connection.
      */
-    func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
+    func bind<CB0: Encodable, CB1: Encodable>(
         _ name: String,
-        to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
+        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
     )
 
     /**
@@ -399,6 +399,16 @@ public extension Binder {
      */
     func bind<CB0: Encodable, CB1: Encodable>(
         _ function: @escaping (@escaping (CB0, CB1) -> Void) throws -> Void,
+        as name: String
+    ) {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R,
         as name: String
     ) {
         bind(name, to: function)

--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -70,9 +70,25 @@ public protocol Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    )
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
+    )
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
     )
 
     /**
@@ -121,6 +137,14 @@ public protocol Binder {
     func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (A0, @escaping (CB0, CB1) -> Void) throws -> R
+    ) where A0: Decodable
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<A0, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
     ) where A0: Decodable
 
     /**
@@ -182,6 +206,22 @@ public protocol Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<A0, A1, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, A1, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<A0, A1, A2, A3>(
         _ name: String,
         to function: @escaping (A0, A1, A2, A3) throws -> Void
@@ -225,6 +265,22 @@ public protocol Binder {
     func bind<R: Encodable, A0, A1, A2, CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> R
+    ) where A0: Decodable, A1: Decodable, A2: Decodable
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) where A0: Decodable, A1: Decodable, A2: Decodable
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, A1, A2, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
     ) where A0: Decodable, A1: Decodable, A2: Decodable
 
     /**
@@ -351,8 +407,18 @@ public extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void,
+        as name: String
+    ) {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
-        _ function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R,
+        _ function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
         as name: String
     ) {
         bind(name, to: function)
@@ -401,16 +467,6 @@ public extension Binder {
     /**
      Bind the specified function to this connection.
      */
-    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
-        _ function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
-        as name: String
-    ) where A0: Decodable {
-        bind(name, to: function)
-    }
-
-    /**
-     Bind the specified function to this connection.
-     */
     func bind<A0, CB0: Encodable, CB1: Encodable>(
         _ function: @escaping (A0, @escaping (CB0, CB1) -> Void) throws -> Void,
         as name: String
@@ -423,6 +479,26 @@ public extension Binder {
      */
     func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
         _ function: @escaping (A0, @escaping (CB0, CB1) -> Void) throws -> R,
+        as name: String
+    ) where A0: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<A0, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void,
+        as name: String
+    ) where A0: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
         as name: String
     ) where A0: Decodable {
         bind(name, to: function)
@@ -491,6 +567,26 @@ public extension Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<A0, A1, CB0, CB1>(
+        _ function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void,
+        as name: String
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, A1, CB0, CB1>(
+        _ function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
+        as name: String
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<A0, A1, A2, A3>(
         _ function: @escaping (A0, A1, A2, A3) throws -> Void,
         as name: String
@@ -543,6 +639,26 @@ public extension Binder {
      */
     func bind<R: Encodable, A0, A1, A2, CB0: Encodable, CB1: Encodable>(
         _ function: @escaping (A0, A1, A2, @escaping (CB0, CB1) -> Void) throws -> R,
+        as name: String
+    ) where A0: Decodable, A1: Decodable, A2: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<A0, A1, A2, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void,
+        as name: String
+    ) where A0: Decodable, A1: Decodable, A2: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, A1, A2, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
         as name: String
     ) where A0: Decodable, A1: Decodable, A2: Decodable {
         bind(name, to: function)

--- a/platforms/apple/Sources/Nimbus/Binder.swift
+++ b/platforms/apple/Sources/Nimbus/Binder.swift
@@ -126,6 +126,14 @@ public protocol Binder {
     /**
      Bind the specified function to this connection.
      */
+    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) where A0: Decodable
+
+    /**
+     Bind the specified function to this connection.
+     */
     func bind<A0, A1, A2>(
         _ name: String,
         to function: @escaping (A0, A1, A2) throws -> Void
@@ -385,6 +393,16 @@ public extension Binder {
      */
     func bind<R: Encodable, A0, CB0: Encodable>(
         _ function: @escaping (A0, @escaping (CB0) -> Void) throws -> R,
+        as name: String
+    ) where A0: Decodable {
+        bind(name, to: function)
+    }
+
+    /**
+     Bind the specified function to this connection.
+     */
+    func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
+        _ function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R,
         as name: String
     ) where A0: Decodable {
         bind(name, to: function)

--- a/platforms/apple/Sources/Nimbus/CallableBinder.swift
+++ b/platforms/apple/Sources/Nimbus/CallableBinder.swift
@@ -128,6 +128,18 @@ extension CallableBinder {
         }
     }
 
+    public func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
+    ) {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 1, actual: args.count)
+            let callback = try self.callback(from: args[0], taking: (CB0.self, CB1.self)).get()
+            return try self.encode(function(callback)).get()
+        }
+    }
+
     public func bind<CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
@@ -138,18 +150,6 @@ extension CallableBinder {
             let cb0 = try self.callback(from: args[0], taking: CB0.self).get()
             let cb1 = try self.callback(from: args[1], taking: CB1.self).get()
             return try function(cb0, cb1)
-        }
-    }
-
-    public func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
-        _ name: String,
-        to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
-    ) {
-        bindCallable(name) { [weak self] (args: [Any?]) in
-            guard let self = self else { throw DecodeError() }
-            try self.assertArgsCount(expected: 1, actual: args.count)
-            let callback = try self.callback(from: args[0], taking: (CB0.self, CB1.self)).get()
-            return try self.encode(function(callback)).get()
         }
     }
 

--- a/platforms/apple/Sources/Nimbus/CallableBinder.swift
+++ b/platforms/apple/Sources/Nimbus/CallableBinder.swift
@@ -6,7 +6,7 @@
 // root or https://opensource.org/licenses/BSD-3-Clause
 //
 
-// swiftlint:disable identifier_name
+// swiftlint:disable identifier_name file_length
 
 typealias Callable = ([Any?]) throws -> Any?
 
@@ -128,6 +128,19 @@ extension CallableBinder {
         }
     }
 
+    public func bind<CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 2, actual: args.count)
+            let cb0 = try self.callback(from: args[0], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[1], taking: CB1.self).get()
+            return try function(cb0, cb1)
+        }
+    }
+
     public func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (@escaping (CB0, CB1) -> Void) throws -> R
@@ -137,6 +150,19 @@ extension CallableBinder {
             try self.assertArgsCount(expected: 1, actual: args.count)
             let callback = try self.callback(from: args[0], taking: (CB0.self, CB1.self)).get()
             return try self.encode(function(callback)).get()
+        }
+    }
+
+    public func bind<R: Encodable, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (@escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 2, actual: args.count)
+            let cb0 = try self.callback(from: args[0], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[1], taking: CB1.self).get()
+            return try self.encode(function(cb0, cb1)).get()
         }
     }
 
@@ -218,6 +244,20 @@ extension CallableBinder {
         }
     }
 
+    public func bind<A0, CB0: Encodable, CB1: Encodable>(
+        _ name: String,
+        to function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) where A0: Decodable {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 3, actual: args.count)
+            let a0 = try self.decode(args[0], as: A0.self).get()
+            let cb0 = try self.callback(from: args[1], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[2], taking: CB1.self).get()
+            return try function(a0, cb0, cb1)
+        }
+    }
+
     public func bind<R: Encodable, A0, CB0: Encodable, CB1: Encodable>(
         _ name: String,
         to function: @escaping (A0, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
@@ -226,9 +266,9 @@ extension CallableBinder {
             guard let self = self else { throw DecodeError() }
             try self.assertArgsCount(expected: 3, actual: args.count)
             let a0 = try self.decode(args[0], as: A0.self).get()
-            let firstCallback = try self.callback(from: args[1], taking: CB0.self).get()
-            let seconCallback = try self.callback(from: args[2], taking: CB1.self).get()
-            return try self.encode(function(a0, firstCallback, seconCallback)).get()
+            let cb0 = try self.callback(from: args[1], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[2], taking: CB1.self).get()
+            return try self.encode(function(a0, cb0, cb1)).get()
         }
     }
 
@@ -313,6 +353,36 @@ extension CallableBinder {
             let a1 = try self.decode(args[1], as: A1.self).get()
             let callback = try self.callback(from: args[2], taking: (CB0.self, CB1.self)).get()
             return try self.encode(function(a0, a1, callback)).get()
+        }
+    }
+
+    public func bind<A0, A1, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 4, actual: args.count)
+            let a0 = try self.decode(args[0], as: A0.self).get()
+            let a1 = try self.decode(args[1], as: A1.self).get()
+            let cb0 = try self.callback(from: args[2], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[3], taking: CB1.self).get()
+            return try function(a0, a1, cb0, cb1)
+        }
+    }
+
+    public func bind<R: Encodable, A0, A1, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) where A0: Decodable, A1: Decodable, CB0: Encodable, CB1: Encodable {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 4, actual: args.count)
+            let a0 = try self.decode(args[0], as: A0.self).get()
+            let a1 = try self.decode(args[1], as: A1.self).get()
+            let cb0 = try self.callback(from: args[2], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[3], taking: CB1.self).get()
+            return try self.encode(function(a0, a1, cb0, cb1)).get()
         }
     }
 
@@ -403,6 +473,38 @@ extension CallableBinder {
             let a2 = try self.decode(args[2], as: A2.self).get()
             let callback = try self.callback(from: args[3], taking: (CB0.self, CB1.self)).get()
             return try self.encode(function(a0, a1, a2, callback)).get()
+        }
+    }
+
+    public func bind<A0, A1, A2, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> Void
+    ) where A0: Decodable, A1: Decodable, A2: Decodable, CB0: Encodable, CB1: Encodable {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 5, actual: args.count)
+            let a0 = try self.decode(args[0], as: A0.self).get()
+            let a1 = try self.decode(args[1], as: A1.self).get()
+            let a2 = try self.decode(args[2], as: A2.self).get()
+            let cb0 = try self.callback(from: args[3], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[4], taking: CB1.self).get()
+            return try function(a0, a1, a2, cb0, cb1)
+        }
+    }
+
+    public func bind<R: Encodable, A0, A1, A2, CB0, CB1>(
+        _ name: String,
+        to function: @escaping (A0, A1, A2, @escaping (CB0) -> Void, @escaping (CB1) -> Void) throws -> R
+    ) where A0: Decodable, A1: Decodable, A2: Decodable, CB0: Encodable, CB1: Encodable {
+        bindCallable(name) { [weak self] (args: [Any?]) in
+            guard let self = self else { throw DecodeError() }
+            try self.assertArgsCount(expected: 5, actual: args.count)
+            let a0 = try self.decode(args[0], as: A0.self).get()
+            let a1 = try self.decode(args[1], as: A1.self).get()
+            let a2 = try self.decode(args[2], as: A2.self).get()
+            let cb0 = try self.callback(from: args[3], taking: CB0.self).get()
+            let cb1 = try self.callback(from: args[4], taking: CB1.self).get()
+            return try self.encode(function(a0, a1, a2, cb0, cb1)).get()
         }
     }
 

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -213,6 +213,91 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
+    func testBindBinaryWithTwoUnaryCallback() {
+        binder.bind(binder.target.binaryWithTwoUnaryCallback, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        _ = try? binder.callable([cb0, cb1])
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(37))
+        XCTAssertEqual(result1, .some(37))
+    }
+
+    func testBindBinaryWithTwoUnaryCallbackThrows() {
+        binder.bind(binder.target.binaryWithTwoUnaryCallbackThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(37))
+        XCTAssertEqual(result1, .some(37))
+    }
+
+    func testBindBinaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.binaryWithTwoUnaryCallbackWithReturn, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([cb0, cb1]) as? Int
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(value, .some(37))
+        XCTAssertEqual(result0, .some(37))
+        XCTAssertEqual(result1, .some(37))
+    }
+
+    func testBindBinaryWithTwoUnaryCallbackWithReturnThrows() {
+        binder.bind(binder.target.binaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(37))
+        XCTAssertEqual(result1, .some(37))
+    }
+
     func testBindTernaryNoReturn() {
         binder.bind(binder.target.ternaryNoReturn, as: "")
         _ = try? binder.callable([42, 37, 13])
@@ -288,21 +373,63 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
-    func testBindTernaryWithTwoUnaryCallbackWithReturnThrows() {
-        binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
-        let expecter0 = expectation(description: "callback0")
-        let expecter1 = expectation(description: "callback0")
+    func testBindTernaryWithTwoUnaryCallback() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallback, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
         var result0: Int?
         var result1: Int?
-        let callback0: BindTarget.UnaryCallback = { value in
+        let cb0: BindTarget.UnaryCallback = { value in
             result0 = value
             expecter0.fulfill()
         }
-        let callback1: BindTarget.UnaryCallback = { value in
+        let cb1: BindTarget.UnaryCallback = { value in
             result1 = value
             expecter1.fulfill()
         }
-        let value = try? binder.callable([42, callback0, callback1]) as? Int
+        _ = try? binder.callable([42, cb0, cb1])
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(42))
+    }
+
+    func testBindTernaryWithTwoUnaryCallbackThrows() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallbackThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(42))
+        XCTAssert(binder.target.called)
+    }
+
+    func testBindTernaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturn, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([42, cb0, cb1]) as? Int
         wait(for: [expecter0, expecter1], timeout: 5)
         XCTAssert(binder.target.called)
         XCTAssertEqual(value, .some(42))
@@ -310,10 +437,25 @@ class BinderTests: XCTestCase {
         XCTAssertEqual(result1, .some(42))
     }
 
-    func testBindQuaternaryNoReturn() {
-        binder.bind(binder.target.quaternaryNoReturn, as: "")
-        _ = try? binder.callable([42, 37, 13, 7])
+    func testBindTernaryWithTwoUnaryCallbackWithReturnThrows() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
         XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(42))
     }
 
     func testBindQuaternaryNoReturnThrows() {
@@ -383,6 +525,91 @@ class BinderTests: XCTestCase {
         XCTAssertThrowsError(try binder.callable([42, 37, 13, callback]))
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
+    }
+
+    func testBindQuaternaryWithTwoUnaryCallback() {
+        binder.bind(binder.target.quaternaryWithTwoUnaryCallback, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        _ = try? binder.callable([42, 37, cb0, cb1])
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(37))
+    }
+
+    func testBindQuaternaryWithTwoUnaryCallbackThrows() {
+        binder.bind(binder.target.quaternaryWithTwoUnaryCallbackThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, 37, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(37))
+        XCTAssert(binder.target.called)
+    }
+
+    func testBindQuaternaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.quaternaryWithTwoUnaryCallbackWithReturn, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([42, 37, cb0, cb1]) as? Int
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(value, .some(79))
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(37))
+    }
+
+    func testBindQuaternaryWithTwoUnaryCallbackWithReturnThrows() {
+        binder.bind(binder.target.quaternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, 37, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(37))
     }
 
     func testBindQuinaryNoReturn() {
@@ -458,6 +685,91 @@ class BinderTests: XCTestCase {
         XCTAssertThrowsError(try binder.callable([42, 37, 13, 7, callback]))
         wait(for: [expecter], timeout: 5)
         XCTAssert(binder.target.called)
+    }
+
+    func testBindQuinaryWithTwoUnaryCallback() {
+        binder.bind(binder.target.quinaryWithTwoUnaryCallback, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        _ = try? binder.callable([42, 37, 13, cb0, cb1])
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(79))
+        XCTAssertEqual(result1, .some(50))
+    }
+
+    func testBindQuinaryWithTwoUnaryCallbackThrows() {
+        binder.bind(binder.target.quinaryWithTwoUnaryCallbackThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, 37, 13, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssertEqual(result0, .some(79))
+        XCTAssertEqual(result1, .some(50))
+        XCTAssert(binder.target.called)
+    }
+
+    func testBindQuinaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.quinaryWithTwoUnaryCallbackWithReturn, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([42, 37, 13, cb0, cb1]) as? Int
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(value, .some(92))
+        XCTAssertEqual(result0, .some(79))
+        XCTAssertEqual(result1, .some(50))
+    }
+
+    func testBindQuinaryWithTwoUnaryCallbackWithReturnThrows() {
+        binder.bind(binder.target.quinaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "cb0")
+        let expecter1 = expectation(description: "cb1")
+        var result0: Int?
+        var result1: Int?
+        let cb0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let cb1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        XCTAssertThrowsError(try binder.callable([42, 37, 13, cb0, cb1]))
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(result0, .some(79))
+        XCTAssertEqual(result1, .some(50))
     }
 }
 
@@ -572,6 +884,33 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func binaryWithTwoUnaryCallback(callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) {
+        called = true
+        callback0(37)
+        callback1(37)
+    }
+
+    func binaryWithTwoUnaryCallbackThrows(callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(37)
+        callback1(37)
+        throw BindError.boundMethodThrew
+    }
+
+    func binaryWithTwoUnaryCallbackWithReturn(callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) -> Int {
+        called = true
+        callback0(37)
+        callback1(37)
+        return 37
+    }
+
+    func binaryWithTwoUnaryCallbackWithReturnThrows(callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int {
+        called = true
+        callback0(37)
+        callback1(37)
+        throw BindError.boundMethodThrew
+    }
+
     func ternaryNoReturn(arg0: Int, arg1: Int, arg2: Int) {
         called = true
     }
@@ -613,11 +952,31 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
-    func ternaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) -> Int {
+    func ternaryWithTwoUnaryCallback(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(arg0)
+        callback1(arg0)
+    }
+
+    func ternaryWithTwoUnaryCallbackThrows(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(arg0)
+        callback1(arg0)
+        throw BindError.boundMethodThrew
+    }
+
+    func ternaryWithTwoUnaryCallbackWithReturn(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int {
         called = true
         callback0(arg0)
         callback1(arg0)
         return arg0
+    }
+
+    func ternaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0)
+        callback1(arg0)
+        throw BindError.boundMethodThrew
     }
 
     func quaternaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) {
@@ -661,6 +1020,33 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func quaternaryWithTwoUnaryCallback(arg0: Int, arg1: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(arg0)
+        callback1(arg1)
+    }
+
+    func quaternaryWithTwoUnaryCallbackThrows(arg0: Int, arg1: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(arg0)
+        callback1(arg1)
+        throw BindError.boundMethodThrew
+    }
+
+    func quaternaryWithTwoUnaryCallbackWithReturn(arg0: Int, arg1: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0)
+        callback1(arg1)
+        return arg0 + arg1
+    }
+
+    func quaternaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, arg1: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0)
+        callback1(arg1)
+        throw BindError.boundMethodThrew
+    }
+
     func quinaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int, arg4: Int) {
         called = true
     }
@@ -699,6 +1085,33 @@ class BindTarget {
     func quinaryWithBinaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, arg3: Int, callback: @escaping BinaryCallback) throws {
         called = true
         callback(arg0 + arg2, arg1 + arg3)
+        throw BindError.boundMethodThrew
+    }
+
+    func quinaryWithTwoUnaryCallback(arg0: Int, arg1: Int, arg2: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws {
+        called = true
+        callback0(arg0 + arg1)
+        callback1(arg1 + arg2)
+    }
+
+    func quinaryWithTwoUnaryCallbackThrows(arg0: Int, arg1: Int, arg2: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0 + arg1)
+        callback1(arg1 + arg2)
+        throw BindError.boundMethodThrew
+    }
+
+    func quinaryWithTwoUnaryCallbackWithReturn(arg0: Int, arg1: Int, arg2: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0 + arg1)
+        callback1(arg1 + arg2)
+        return arg0 + arg1 + arg2
+    }
+
+    func quinaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, arg1: Int, arg2: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) throws -> Int { // swiftlint:disable:this line_length
+        called = true
+        callback0(arg0 + arg1)
+        callback1(arg1 + arg2)
         throw BindError.boundMethodThrew
     }
 }

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -288,7 +288,7 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
-    func testBindTernaryWithTwoUnaryCallbackWithReturn() {
+    func testBindTernaryWithTwoUnaryCallbackWithReturnThrows() {
         binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
         let expecter0 = expectation(description: "callback0")
         let expecter1 = expectation(description: "callback0")

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -619,7 +619,7 @@ class BindTarget {
         callback1(arg0)
         return arg0
     }
-    
+
     func quaternaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) {
         called = true
     }

--- a/platforms/apple/Sources/NimbusTests/BinderTests.swift
+++ b/platforms/apple/Sources/NimbusTests/BinderTests.swift
@@ -288,6 +288,28 @@ class BinderTests: XCTestCase {
         XCTAssert(binder.target.called)
     }
 
+    func testBindTernaryWithTwoUnaryCallbackWithReturn() {
+        binder.bind(binder.target.ternaryWithTwoUnaryCallbackWithReturnThrows, as: "")
+        let expecter0 = expectation(description: "callback0")
+        let expecter1 = expectation(description: "callback0")
+        var result0: Int?
+        var result1: Int?
+        let callback0: BindTarget.UnaryCallback = { value in
+            result0 = value
+            expecter0.fulfill()
+        }
+        let callback1: BindTarget.UnaryCallback = { value in
+            result1 = value
+            expecter1.fulfill()
+        }
+        let value = try? binder.callable([42, callback0, callback1]) as? Int
+        wait(for: [expecter0, expecter1], timeout: 5)
+        XCTAssert(binder.target.called)
+        XCTAssertEqual(value, .some(42))
+        XCTAssertEqual(result0, .some(42))
+        XCTAssertEqual(result1, .some(42))
+    }
+
     func testBindQuaternaryNoReturn() {
         binder.bind(binder.target.quaternaryNoReturn, as: "")
         _ = try? binder.callable([42, 37, 13, 7])
@@ -591,6 +613,13 @@ class BindTarget {
         throw BindError.boundMethodThrew
     }
 
+    func ternaryWithTwoUnaryCallbackWithReturnThrows(arg0: Int, callback0: @escaping UnaryCallback, callback1: @escaping UnaryCallback) -> Int {
+        called = true
+        callback0(arg0)
+        callback1(arg0)
+        return arg0
+    }
+    
     func quaternaryNoReturn(arg0: Int, arg1: Int, arg2: Int, arg3: Int) {
         called = true
     }


### PR DESCRIPTION
These overloaded `bind` methods are unique in that they take a second callback as one of the arguments.

Android already supports the second callback via its @BoundMethod annotation.