### PR TITLE
Android Event Publishing

### DIFF
--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -587,6 +587,7 @@ function subscribeToStructEvent() {
     __nimbus.plugins.expectPlugin.finished();
   }).then((listen) => {
     listenerID = listen;
+    __nimbus.plugins.expectPlugin.ready();
   });
 }
 

--- a/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -452,7 +452,7 @@ class V8BinderGenerator : BinderGenerator() {
         argBlock
             .addStatement(")")
             .addStatement(
-                "callback$parameterIndex.use { it.call(v8, params.%T(v8)) }",
+                "callback$parameterIndex.call(v8, params.%T(v8))",
                 ClassName(k2v8Package, "toV8Array")
             )
 

--- a/platforms/android/core/build.gradle
+++ b/platforms/android/core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     compileOnly "com.salesforce.k2v8:k2v8:$k2v8_version"
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$kotlin_test_runner_version"
     testImplementation "org.json:json:$json_version"
+    testImplementation "org.jetbrains.kotlinx:kotlinx-serialization-runtime:$kotlin_serialization_version"
 }
 
 task sourcesJar(type: Jar) {

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/DefaultEventPublisher.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/DefaultEventPublisher.kt
@@ -1,0 +1,43 @@
+package com.salesforce.nimbus
+
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Default implementation of [EventPublisher].
+ */
+class DefaultEventPublisher<E : Event> : EventPublisher<E> {
+    private val listeners: MutableMap<String, MutableMap<String, (E) -> Unit>> = ConcurrentHashMap()
+
+    /**
+     * @see [EventPublisher.publishEvent]
+     */
+    override fun publishEvent(event: E) {
+        listeners[event.name]?.values?.forEach { listener -> listener(event) }
+    }
+
+    /**
+     * @see [EventPublisher.addListener]
+     */
+    override fun addListener(eventName: String, listener: (E) -> Unit): String {
+
+        // create a UUID to return so that the listener can later be removed
+        val listenerId = UUID.randomUUID().toString()
+
+        // get our map of listenerId -> listener by event name
+        val listenerMap = listeners.getOrPut(eventName) { mutableMapOf() }
+
+        // add the new listener to the map
+        listenerMap[listenerId] = listener
+
+        // return the UUID
+        return listenerId
+    }
+
+    /**
+     * @see [EventPublisher.removeListener]
+     */
+    override fun removeListener(listenerId: String) {
+        listeners.values.forEach { listenerMap -> listenerMap.remove(listenerId) }
+    }
+}

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Event.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Event.kt
@@ -1,0 +1,14 @@
+package com.salesforce.nimbus
+
+/**
+ * Defines an event that can be published by an [EventPublisher].
+ *
+ * NOTE: The class which implements this interface must also be [Serializable].
+ */
+interface Event {
+
+    /**
+     * The name of the event which is used when subscribing via [EventPublisher.addListener].
+     */
+    val name: String
+}

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/EventPublisher.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/EventPublisher.kt
@@ -1,0 +1,24 @@
+package com.salesforce.nimbus
+
+/**
+ * Defines a [Plugin] which can publish [Event]s of type [E] to a listener who has subscribed to those events.
+ */
+interface EventPublisher<E : Event> {
+
+    /**
+     * Publishes an event [E] to any listeners which are subscribed to the [Event.name].
+     */
+    fun publishEvent(event: E)
+
+    /**
+     * Add a listener for events with the [eventName] specified.
+     *
+     * @return a UUID which can later be used to remove the listener via [removeListener]
+     */
+    fun addListener(eventName: String, listener: (E) -> Unit): String
+
+    /**
+     * Removes a listener using the UUID returned from [addListener].
+     */
+    fun removeListener(listenerId: String)
+}

--- a/platforms/android/core/src/test/java/com/salesforce/nimbus/DefaultEventPublisherTest.kt
+++ b/platforms/android/core/src/test/java/com/salesforce/nimbus/DefaultEventPublisherTest.kt
@@ -1,0 +1,106 @@
+package com.salesforce.nimbus
+
+import kotlinx.serialization.Serializable
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+sealed class TestEvents : Event {
+
+    @Serializable
+    data class TestEventOne(val message: String) : TestEvents() {
+        override val name: String = "testEventOne"
+    }
+
+    @Serializable
+    data class TestEventTwo(val thingOne: Int, val thingTwo: Boolean) : TestEvents() {
+        override val name: String = "testEventTwo"
+    }
+}
+
+class DefaultEventPublisherTest {
+    private lateinit var eventPublisher: DefaultEventPublisher<TestEvents>
+    private var eventOneListenerCalledWithCorrectData = false
+    private lateinit var eventOneListenerId: String
+    private var eventTwoListenerCalledWithCorrectData = false
+    private lateinit var eventTwoListenerId: String
+
+    @Before
+    fun setUp() {
+        eventPublisher = DefaultEventPublisher<TestEvents>().apply {
+            eventOneListenerId = addListener("testEventOne") {
+                eventOneListenerCalledWithCorrectData =
+                    it is TestEvents.TestEventOne && it.message == "testMessage"
+            }
+            eventTwoListenerId = addListener("testEventTwo") {
+                eventTwoListenerCalledWithCorrectData =
+                    it is TestEvents.TestEventTwo && it.thingOne == 1 && it.thingTwo == true
+            }
+        }
+    }
+
+    @Test
+    fun `TestEventOne listener is invoked`() {
+
+        // publish event
+        eventPublisher.publishEvent(TestEvents.TestEventOne(message = "testMessage"))
+
+        // make sure listener received correct data
+        assertTrue(eventOneListenerCalledWithCorrectData)
+
+        // reset
+        eventOneListenerCalledWithCorrectData = false
+
+        // publish another event
+        eventPublisher.publishEvent(TestEvents.TestEventOne(message = "testMessage"))
+
+        // make sure listener received correct data again
+        assertTrue(eventOneListenerCalledWithCorrectData)
+    }
+
+    @Test
+    fun `TestEventTwo listener is invoked`() {
+
+        // publish event
+        eventPublisher.publishEvent(TestEvents.TestEventTwo(thingOne = 1, thingTwo = true))
+
+        // make sure listener received correct data
+        assertTrue(eventTwoListenerCalledWithCorrectData)
+
+        // reset
+        eventTwoListenerCalledWithCorrectData = false
+
+        // publish another event
+        eventPublisher.publishEvent(TestEvents.TestEventTwo(thingOne = 1, thingTwo = true))
+
+        // make sure listener received correct data again
+        assertTrue(eventTwoListenerCalledWithCorrectData)
+    }
+
+    @Test
+    fun `TestEventOne listener is not invoked after removed`() {
+
+        // remove listener
+        eventPublisher.removeListener(eventOneListenerId)
+
+        // publish event
+        eventPublisher.publishEvent(TestEvents.TestEventOne(message = "testMessage"))
+
+        // make sure listener was never called
+        assertFalse(eventOneListenerCalledWithCorrectData)
+    }
+
+    @Test
+    fun `TestEventTwo listener is not invoked after removed`() {
+
+        // remove listener
+        eventPublisher.removeListener(eventTwoListenerId)
+
+        // publish event
+        eventPublisher.publishEvent(TestEvents.TestEventTwo(thingOne = 1, thingTwo = true))
+
+        // make sure listener was never called
+        assertFalse(eventTwoListenerCalledWithCorrectData)
+    }
+}

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/ExpectPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/ExpectPlugin.kt
@@ -8,9 +8,12 @@ import java.util.concurrent.CountDownLatch
 @PluginOptions("expectPlugin")
 class ExpectPlugin : Plugin {
 
-    val testReady = CountDownLatch(1)
-    val testFinished = CountDownLatch(1)
+    var testReady = CountDownLatch(1)
+        private set
+    var testFinished = CountDownLatch(1)
+        private set
     var passed = false
+        private set
 
     @BoundMethod
     fun ready() {
@@ -25,5 +28,11 @@ class ExpectPlugin : Plugin {
     @BoundMethod
     fun finished() {
         testFinished.countDown()
+    }
+
+    fun reset() {
+        testReady = CountDownLatch(1)
+        testFinished = CountDownLatch(1)
+        passed = false
     }
 }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -3,6 +3,9 @@ package com.salesforce.nimbus.bridge.tests.plugin
 import com.salesforce.k2v8.V8ObjectDecoder
 import com.salesforce.k2v8.V8ObjectEncoder
 import com.salesforce.nimbus.BoundMethod
+import com.salesforce.nimbus.DefaultEventPublisher
+import com.salesforce.nimbus.Event
+import com.salesforce.nimbus.EventPublisher
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import kotlinx.serialization.Decoder
@@ -61,8 +64,13 @@ object DateSerializer : KSerializer<Date> {
     }
 }
 
+@Serializable
+class StructEvent(val theStruct: TestStruct) : Event {
+    override val name: String = "structEvent"
+}
+
 @PluginOptions(name = "testPlugin")
-class TestPlugin : Plugin {
+class TestPlugin : Plugin, EventPublisher<StructEvent> by DefaultEventPublisher() {
 
     // region nullary parameters
 

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -256,6 +256,7 @@ class SharedTestsWebView: XCTestCase {
     }
 
     func testEventPublishing() {
+        expectPlugin.readyExpectation = expectation(description: "ready")
         let subscribe = expectation(description: "subscribe")
         webView.evaluateJavaScript("subscribeToStructEvent()") { _, _ in
             subscribe.fulfill()


### PR DESCRIPTION
This is the Android event publishing implementation matching the Plugin Event RFC. There is a new interface called `EventPublisher` which should be implemented by a `Plugin` that wants to support event publishing. The plugin can implement the methods in the interface, however most implementations will just want to delegate to the `DefaultEventPublisher` which handles managing listeners and publishing events. This is what that property delegation looks like:
```
class MyPlugin : Plugin, EventPublisher<MyEvent> by DefaultEventPublisher() {...}
```
There is an interface called `Event` which each concrete event class needs to implement. Also, the implementation of `Event` must be `@Serializable` which is enforced by the compiler.

Here is an example of defining a single event class:
```
class MyEvent : Event {
    override val name: String = "myEvent"
}
```
The implementation must override the `name` property of `Event` to provide the name of the event for which it can be listened for when registering a listener, like this:
```
__nimbus.plugins.MyPlugin.addListener("myEvent", (event) => {...});
```
This implementation also supports multiple event types in a single publisher. This is what that might look like:
```
sealed class MyEvents : Event {

    @Serializable
    data class EventOne(val someString: String): MyEvents() {
        override val name: String = "eventOne"
    }

    @Serializable
    data class EventTwo(val someInt: Int): MyEvents() {
        override val name: String = "eventTwo"
    }
}
```

Then, a plugin can publish the event to listeners like this:
```
    val myPlugin = MyPlugin()
    myPlugin.publishEvent(EventOne())
    myPlugin.publishEvent(EventTwo())
```