### PR TITLE
Promise rejection fix (#224)

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -129,13 +129,17 @@ let promisify = (src: any): void => {
   let dest: any = {};
   Object.keys(src).forEach((key): void => {
     let func = src[key];
-    dest[key] = (...args: any[]): any => {
+    dest[key] = (...args: any[]): Promise<any> => {
       args = cloneArguments(args);
-      let result = func.call(src, ...args);
-      if (result !== undefined) {
-        result = JSON.parse(result);
+      try {
+        let result = func.call(src, ...args);
+        if (result !== undefined) {
+          result = JSON.parse(result);
+        }
+        return Promise.resolve(result);
+      } catch (error) {
+        return Promise.reject(error);
       }
-      return Promise.resolve(result);
     };
   });
   return dest;
@@ -155,7 +159,7 @@ let releaseCallback = (callbackId: string): void => {
 // in the storage
 let resolvePromise = (promiseUuid: string, data: any, error: any): void => {
   if (error) {
-    uuidsToPromises[promiseUuid].reject(data);
+    uuidsToPromises[promiseUuid].reject(error);
   } else {
     uuidsToPromises[promiseUuid].resolve(data);
   }

--- a/packages/test-www/test/callback-encodable-tests.ts
+++ b/packages/test-www/test/callback-encodable-tests.ts
@@ -25,6 +25,9 @@ interface CallbackTestPlugin {
   callbackWithPrimitiveAndUddtParams(
     completion: (param0: number, param1: MochaMessage) => void
   ): void;
+  promiseResolved(): Promise<string>;
+  promiseRejected(): Promise<string>;
+  promiseRejectedEncoded(): Promise<string>;
 }
 
 declare module "nimbus-types" {
@@ -92,5 +95,23 @@ describe("Callbacks with", () => {
         done();
       }
     );
+  });
+
+  it("promise resolves and passes the value", (done) => {
+    __nimbus.plugins.callbackTestPlugin
+      .promiseResolved()
+      .then((result: string) => {
+        expect(result).to.equal("promise");
+        done();
+      });
+  });
+
+  it("promise rejects and passes the error", (done) => {
+    __nimbus.plugins.callbackTestPlugin
+      .promiseRejected()
+      .then((_) => done("unexpected completion"))
+      .catch((_) => {
+        done();
+      });
   });
 });

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/CallbackTestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/CallbackTestPlugin.kt
@@ -6,6 +6,7 @@ import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.bridge.tests.webview.WebViewMochaTests
 import org.json.JSONArray
 import org.json.JSONObject
+import java.lang.Exception
 
 @PluginOptions(name = "callbackTestPlugin")
 class CallbackTestPlugin : Plugin {
@@ -103,5 +104,13 @@ class CallbackTestPlugin : Plugin {
         jo1.put("five", 5)
         jo1.put("six", 6)
         arg(jo0, jo1)
+    }
+
+    @BoundMethod
+    fun promiseResolved(): String = "promise"
+
+    @BoundMethod
+    fun promiseRejected() {
+        throw Exception()
     }
 }

--- a/platforms/apple/Sources/Nimbus/EncodableValue.swift
+++ b/platforms/apple/Sources/Nimbus/EncodableValue.swift
@@ -15,12 +15,17 @@ import Foundation
  Once `JSONEncoder` supports encoding top-level fragments this can
  be removed.
  */
+
+public typealias EncodableError = Error & Encodable
+
 public enum EncodableValue: Encodable {
     case void
     case value(Encodable)
+    case error(EncodableError)
 
     enum Keys: String, CodingKey {
         case v // swiftlint:disable:this identifier_name
+        case e // swiftlint:disable:this identifier_name
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -31,6 +36,9 @@ public enum EncodableValue: Encodable {
         case let .value(value):
             let superContainer = container.superEncoder(forKey: .v)
             try value.encode(to: superContainer)
+        case let .error(error):
+            let superContainer = container.superEncoder(forKey: .e)
+            try error.encode(to: superContainer)
         }
     }
 }

--- a/platforms/apple/Sources/NimbusTests/MochaTests.swift
+++ b/platforms/apple/Sources/NimbusTests/MochaTests.swift
@@ -241,6 +241,11 @@ struct MochaMessage: Encodable {
     var intField = 42
 }
 
+public struct TestError: Error, Encodable {
+    let code: Int
+    let message: String
+}
+
 public class CallbackTestPlugin {
     func callbackWithSingleParam(completion: @escaping (MochaMessage) -> Swift.Void) {
         let mochaMessage = MochaMessage()
@@ -265,6 +270,22 @@ public class CallbackTestPlugin {
     func callbackWithPrimitiveAndUddtParams(completion: @escaping (Int, MochaMessage) -> Swift.Void) {
         completion(777, MochaMessage())
     }
+
+    func promiseResolved() -> String {
+        return "promise"
+    }
+
+    func promiseRejectedEncoded() throws -> String {
+        throw TestError(code: 42, message: "mock promise rejection")
+    }
+
+    func promiseRejected() throws -> String {
+        throw MockError.rejectedError
+    }
+}
+
+enum MockError: Error {
+    case rejectedError
 }
 
 extension CallbackTestPlugin: Plugin {
@@ -278,6 +299,9 @@ extension CallbackTestPlugin: Plugin {
         connection.bind(callbackWithSinglePrimitiveParam, as: "callbackWithSinglePrimitiveParam")
         connection.bind(callbackWithTwoPrimitiveParams, as: "callbackWithTwoPrimitiveParams")
         connection.bind(callbackWithPrimitiveAndUddtParams, as: "callbackWithPrimitiveAndUddtParams")
+        connection.bind(promiseResolved, as: "promiseResolved")
+        connection.bind(promiseRejectedEncoded, as: "promiseRejectedEncoded")
+        connection.bind(promiseRejected, as: "promiseRejected")
     }
 }
 


### PR DESCRIPTION
* send the error when rejecting the promise

* iOS now correctly passes Error's to the promise rejection.
iOS rejection errors can now also be Encodable Error structures/classes.

* make the linter happy

* send interpolated error if unable to decode

* Ensure promises get rejected on android when an exception is thrown

Co-authored-by: Jason Foreman <jforeman@salesforce.com>