### PR TITLE
Added event publishing example to demo app

### DIFF
--- a/packages/demo-www/src/components/app.ts
+++ b/packages/demo-www/src/components/app.ts
@@ -1,4 +1,7 @@
 import nimbus from "nimbus-types";
+import "../plugins/log";
+import "../plugins/toast";
+import "../plugins/events";
 
 const template = document.createElement("template");
 template.innerHTML = `
@@ -14,6 +17,20 @@ class NimbusDemoApp extends HTMLElement {
 
   public connectedCallback(): void {
     console.log(`component connected ${nimbus}`);
+
+    if (__nimbus.plugins.EventPlugin !== undefined) {
+
+     // listen for log events and then log the message using the log plugin
+     __nimbus.plugins.EventPlugin.addListener("logEvent", (event: LogEvent) => {
+       __nimbus.plugins.LogPlugin.debug("LogPlugin", JSON.stringify(event));
+     });
+
+     // listen for toast events and then toast the message using the toast
+     // plugin
+     __nimbus.plugins.EventPlugin.addListener("toastEvent", (event: ToastEvent) => {
+       __nimbus.plugins.ToastPlugin.toast(event.message);
+     });
+   }
   }
 }
 

--- a/packages/demo-www/src/plugins/events.ts
+++ b/packages/demo-www/src/plugins/events.ts
@@ -1,0 +1,12 @@
+interface LogEvent {
+  message: string;
+}
+
+interface ToastEvent {
+  message: string;
+}
+
+interface MessageEvents {
+  logEvent: LogEvent;
+  toastEvent: ToastEvent;
+}

--- a/packages/demo-www/src/plugins/log.ts
+++ b/packages/demo-www/src/plugins/log.ts
@@ -1,0 +1,9 @@
+export interface LogPlugin {
+  debug(tag: string, message: string): Promise<void>;
+}
+
+declare module 'nimbus-types' {
+  export interface NimbusPlugins {
+    LogPlugin: LogPlugin;
+  }
+}

--- a/packages/demo-www/src/plugins/toast.ts
+++ b/packages/demo-www/src/plugins/toast.ts
@@ -1,0 +1,9 @@
+export interface ToastPlugin {
+  toast(message: string): Promise<void>;
+}
+
+declare module 'nimbus-types' {
+  export interface NimbusPlugins {
+    ToastPlugin: ToastPlugin;
+  }
+}

--- a/platforms/android/build.gradle
+++ b/platforms/android/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
     ext {
-        kotlin_version = '1.3.71'
+        kotlin_version = '1.3.72'
         kotlin_serialization_version = '0.20.0'
         kotlin_metadata_version = '0.1.0'
-        k2v8_version = '0.0.1'
+        k2v8_version = '0.0.2'
         kotlinpoet_version = '1.5.0'
         kotlin_test_runner_version = '3.1.5'
         google_truth_version = '1.0.1'

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/Constants.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/Constants.kt
@@ -1,4 +1,10 @@
 package com.salesforce.nimbus
 
+import kotlinx.serialization.UnstableDefault
+import kotlinx.serialization.json.JsonConfiguration
+
 const val NIMBUS_BRIDGE = "__nimbus"
 const val NIMBUS_PLUGINS = "plugins"
+const val NIMBUS_CLASS_DISCRIMINATOR = "__type"
+@UnstableDefault
+val NIMBUS_JSON_CONFIGURATION = JsonConfiguration(classDiscriminator = NIMBUS_CLASS_DISCRIMINATOR)

--- a/platforms/android/core/src/main/java/com/salesforce/nimbus/PrimitiveJSONEncodableExtensions.kt
+++ b/platforms/android/core/src/main/java/com/salesforce/nimbus/PrimitiveJSONEncodableExtensions.kt
@@ -8,8 +8,8 @@
 package com.salesforce.nimbus
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.HashMap
@@ -32,9 +32,10 @@ class PrimitiveJSONEncodable(val value: Any) : JSONEncodable {
  * A [JSONEncodable] wrapper around an object that is [Serializable] and serialized using a
  * [KSerializer]
  */
+@UnstableDefault
 class KotlinJSONEncodable<T>(private val value: T, private val serializer: KSerializer<T>) : JSONEncodable {
     override fun encode(): String {
-        return Json(JsonConfiguration.Stable).stringify(serializer, value)
+        return Json(NIMBUS_JSON_CONFIGURATION).stringify(serializer, value)
     }
 }
 

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -11,11 +11,15 @@ import android.content.Context
 import android.os.Bundle
 import android.util.Log
 import android.webkit.WebView
+import android.widget.Button
+import android.widget.EditText
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.eclipsesource.v8.V8
-import com.salesforce.k2v8.scope
 import com.salesforce.nimbus.BoundMethod
+import com.salesforce.nimbus.DefaultEventPublisher
+import com.salesforce.nimbus.Event
+import com.salesforce.nimbus.EventPublisher
 import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.bridge.v8.V8Bridge
@@ -25,6 +29,7 @@ import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.core.plugins.DeviceInfoPlugin
 import com.salesforce.nimbus.core.plugins.v8Binder
 import com.salesforce.nimbus.core.plugins.webViewBinder
+import kotlinx.serialization.Serializable
 
 class MainActivity : AppCompatActivity() {
 
@@ -41,9 +46,17 @@ class MainActivity : AppCompatActivity() {
         // create the device info plugin
         val deviceInfoPlugin = DeviceInfoPlugin(this)
 
+        // create some other plugins
+        val logPlugin = LogPlugin()
+        val toastPlugin = ToastPlugin(this)
+        val eventPlugin = EventPlugin()
+
         // create the web view bridge
         webViewBridge = webView.bridge {
             bind { deviceInfoPlugin.webViewBinder() }
+            bind { logPlugin.webViewBinder() }
+            bind { toastPlugin.webViewBinder() }
+            bind { eventPlugin.webViewBinder() }
         }
 
         // load the demo url
@@ -52,28 +65,41 @@ class MainActivity : AppCompatActivity() {
         // create a v8 runtime
         v8 = V8.createV8Runtime()
 
-        // create some plugins for v8
-        val logPlugin = LogPlugin()
-        val toastPlugin = ToastPlugin(this)
-
         // create the v8 bridge
         v8Bridge = v8.bridge {
             bind { deviceInfoPlugin.v8Binder() }
             bind { logPlugin.v8Binder() }
             bind { toastPlugin.v8Binder() }
+            bind { eventPlugin.v8Binder() }
         }
 
         // execute a script to get the device info plugin and then log to the console
-        v8.scope {
-            v8.executeScript(
-                """
-                    __nimbus.plugins.DeviceInfoPlugin.getDeviceInfo().then((deviceInfo) => {
-                        let json = JSON.stringify(deviceInfo);
-                        __nimbus.plugins.LogPlugin.debug('DemoApp', json);
-                        __nimbus.plugins.ToastPlugin.toast('Device Info from V8: ' + json);
-                    });
-                """.trimIndent()
-            )
+        v8.executeScript(
+            """
+                __nimbus.plugins.DeviceInfoPlugin.getDeviceInfo().then((deviceInfo) => {
+                    let json = JSON.stringify(deviceInfo);
+                    __nimbus.plugins.LogPlugin.debug('DemoApp', json);
+                    __nimbus.plugins.ToastPlugin.toast('Device Info from V8: ' + json);
+                });
+
+                __nimbus.plugins.EventPlugin.addListener("logEvent", (event) => {
+                    __nimbus.plugins.LogPlugin.debug("LogPlugin", "V8: " + JSON.stringify(event));
+                });
+
+                __nimbus.plugins.EventPlugin.addListener("toastEvent", (event) => {
+                    __nimbus.plugins.ToastPlugin.toast("V8: " + event.message);
+                });
+            """.trimIndent()
+        )
+
+        val logMessage = findViewById<EditText>(R.id.log_message)
+        findViewById<Button>(R.id.publish_log_event_button).setOnClickListener {
+            eventPlugin.publishEvent(MessageEvents.LogEvent(logMessage.text.toString()))
+        }
+
+        val toastMessage = findViewById<EditText>(R.id.toast_message)
+        findViewById<Button>(R.id.publish_toast_event_button).setOnClickListener {
+            eventPlugin.publishEvent(MessageEvents.ToastEvent(toastMessage.text.toString()))
         }
     }
 
@@ -102,3 +128,20 @@ class ToastPlugin(private val context: Context) : Plugin {
         Toast.makeText(context, message, Toast.LENGTH_LONG).show()
     }
 }
+
+@Serializable
+sealed class MessageEvents : Event {
+
+    @Serializable
+    data class LogEvent(val message: String) : MessageEvents() {
+        override val name: String = "logEvent"
+    }
+
+    @Serializable
+    data class ToastEvent(val message: String) : MessageEvents() {
+        override val name: String = "toastEvent"
+    }
+}
+
+@PluginOptions("EventPlugin")
+class EventPlugin : Plugin, EventPublisher<MessageEvents> by DefaultEventPublisher()

--- a/platforms/android/demo-app/src/main/res/layout/activity_main.xml
+++ b/platforms/android/demo-app/src/main/res/layout/activity_main.xml
@@ -1,7 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<WebView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity"
-    android:id="@+id/webview"/>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              tools:context=".MainActivity"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent"
+              android:orientation="vertical">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp">
+
+        <EditText
+            android:id="@+id/log_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/log_event_message_hint"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/publish_log_event_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" tools:ignore="Autofill,TextFields"/>
+
+        <Button
+            android:id="@+id/publish_log_event_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/publish_button_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="8dp">
+
+        <EditText
+            android:id="@+id/toast_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:hint="@string/toast_event_message_hint"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/publish_toast_event_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent" tools:ignore="Autofill,TextFields"/>
+
+        <Button
+            android:id="@+id/publish_toast_event_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/publish_button_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <WebView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:id="@+id/webview"/>
+
+</LinearLayout>
+

--- a/platforms/android/demo-app/src/main/res/values/strings.xml
+++ b/platforms/android/demo-app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">NimbusDemoApp</string>
+    <string name="publish_button_text">Publish</string>
+    <string name="log_event_message_hint">Enter log event message…</string>
+    <string name="toast_event_message_hint">Enter toast event message…</string>
 </resources>


### PR DESCRIPTION
This PR adds an example of how event publishing works to the demo app. There are two text fields, one which will publish the log plugin (and log to console), the other which will publish to the toast plugin. 

### Changes

- Added event publishing to demo app
- Updated class discriminator for JSON serialization to be same as is with K2V8 serialization
- Updated k2v8 to 0.0.2
- Updated kotlin to 1.3.72