### PR TITLE
Implementation of return value errors on iOS

### DIFF
--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -573,6 +573,32 @@ function verifyBinaryIntResolvingIntCallbackReturnsInt() {
 
 // endregion
 
+// region return value errors
+
+function verifyReturnValueSimpleError() {
+  __nimbus.plugins.testPlugin.nullaryResolvingToSimpleError().then(() => {
+    __nimbus.plugins.expectPlugin.finished();
+  }).catch((error) => {
+    if (error === "simpleError") {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyReturnValueStructuredError() {
+  __nimbus.plugins.testPlugin.nullaryResolvingToStructuredError().then(() => {
+    __nimbus.plugins.expectPlugin.finished();
+  }).catch((error) => {
+    if (error.stringValue === "Structured error" && error.numberValue === 4.0) {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+// endregion
+
 // region events
 
 var listenerID = "";

--- a/platforms/apple/Sources/Nimbus/JSContextConnection.swift
+++ b/platforms/apple/Sources/Nimbus/JSContextConnection.swift
@@ -54,17 +54,17 @@ public class JSContextConnection: Connection, CallableBinder {
             } catch {
                 switch error {
                 case let encodableError as EncodableError:
-                    let error = EncodableValue.error(encodableError)
+                    let encodableError = EncodableValue.error(encodableError)
                     if
                         let promiseGlobal = self.promiseGlobal,
-                        let jsValue = try? JSValueEncoder().encode(error, context: promiseGlobal.context),
+                        let jsValue = try? JSValueEncoder().encode(encodableError, context: promiseGlobal.context),
                         let errorValue = jsValue.objectForKeyedSubscript("e") {
                         return promiseGlobal.invokeMethod("reject", withArguments: [errorValue])
                     } else {
                         fallthrough
                     }
                 default:
-                    return self.promiseGlobal?.invokeMethod("reject", withArguments: [error.localizedDescription])
+                    return self.promiseGlobal?.invokeMethod("reject", withArguments: [String("\(error)")])
                 }
             }
         }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -221,6 +221,14 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyBinaryIntResolvingIntCallbackReturnsInt()")
     }
 
+    func testVerifyReturnValueSimpleError() {
+        executeTest("verifyReturnValueSimpleError()")
+    }
+
+    func testVerifyReturnValueStructuredError() {
+        executeTest("verifyReturnValueStructuredError()")
+    }
+
     func testEventPublishing() {
         context.evaluateScript("subscribeToStructEvent()")
         XCTAssertTrue(expectPlugin.isReady)

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -65,6 +65,8 @@ class TestPlugin: Plugin {
         connection.bind(unaryIntResolvingToIntCallback, as: "unaryIntResolvingToIntCallback")
         connection.bind(binaryIntDoubleResolvingToIntDoubleCallback, as: "binaryIntDoubleResolvingToIntDoubleCallback")
         connection.bind(binaryIntResolvingIntCallbackReturnsInt, as: "binaryIntResolvingIntCallbackReturnsInt")
+        connection.bind(nullaryResolvingToSimpleError, as: "nullaryResolvingToSimpleError")
+        connection.bind(nullaryResolvingToStructuredError, as: "nullaryResolvingToStructuredError")
     }
 
     func nullaryResolvingToInt() -> Int {
@@ -277,6 +279,23 @@ class TestPlugin: Plugin {
         callback(param0 - 1)
         return param0 - 2
     }
+
+    func nullaryResolvingToSimpleError() throws -> String {
+        throw TestSimpleError.simpleError
+    }
+
+    func nullaryResolvingToStructuredError() throws -> String {
+        throw TestStructuredError()
+    }
+}
+
+enum TestSimpleError: Error {
+    case simpleError
+}
+
+struct TestStructuredError: Error, Encodable {
+    let stringValue = "Structured error"
+    let numberValue = 4.0
 }
 
 class ExpectPlugin: Plugin {

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -255,6 +255,14 @@ class SharedTestsWebView: XCTestCase {
         executeTest("verifyBinaryIntResolvingIntCallbackReturnsInt()")
     }
 
+    func testVerifyReturnValueSimpleError() {
+        executeTest("verifyReturnValueSimpleError()")
+    }
+
+    func testVerifyReturnValueStructuredError() {
+        executeTest("verifyReturnValueStructuredError()")
+    }
+
     func testEventPublishing() {
         expectPlugin.readyExpectation = expectation(description: "ready")
         let subscribe = expectation(description: "subscribe")


### PR DESCRIPTION
Most of this was already implemented in `main` but I found a problem in `JSValueEncoder` that was causing the encoding of `EncodableValue` to encode no values. This fixes that, fixes the implementation in JSCore for the simple, non-structured enum, and adds tests to the shared test library for both cases.