### PR TITLE
Generate core plugins in consuming app with new annotation

### DIFF
--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -17,6 +17,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import com.eclipsesource.v8.V8
 import com.salesforce.nimbus.BoundMethod
+import com.salesforce.nimbus.BoundPlugin
 import com.salesforce.nimbus.DefaultEventPublisher
 import com.salesforce.nimbus.Event
 import com.salesforce.nimbus.EventPublisher
@@ -27,12 +28,12 @@ import com.salesforce.nimbus.bridge.v8.bridge
 import com.salesforce.nimbus.bridge.webview.WebViewBridge
 import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.core.plugins.DeviceInfoPlugin
-import com.salesforce.nimbus.core.plugins.v8Binder
-import com.salesforce.nimbus.core.plugins.webViewBinder
 import kotlinx.serialization.Serializable
 
 class MainActivity : AppCompatActivity() {
 
+    @BoundPlugin
+    private lateinit var deviceInfoPlugin: DeviceInfoPlugin
     private lateinit var webViewBridge: WebViewBridge
     private lateinit var v8Bridge: V8Bridge
     private lateinit var v8: V8
@@ -44,7 +45,7 @@ class MainActivity : AppCompatActivity() {
         val webView = findViewById<WebView>(R.id.webview)
 
         // create the device info plugin
-        val deviceInfoPlugin = DeviceInfoPlugin(this)
+        deviceInfoPlugin = DeviceInfoPlugin(this)
 
         // create some other plugins
         val logPlugin = LogPlugin()

--- a/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundMethod.kt
+++ b/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundMethod.kt
@@ -1,5 +1,5 @@
 package com.salesforce.nimbus
 
-@Retention(AnnotationRetention.SOURCE)
+@Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 annotation class BoundMethod

--- a/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundPlugin.kt
+++ b/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundPlugin.kt
@@ -1,0 +1,5 @@
+package com.salesforce.nimbus
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+annotation class BoundPlugin

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/CompilerExtensions.kt
@@ -23,7 +23,9 @@ import kotlinx.metadata.Flag
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmTypeProjection
 import kotlinx.metadata.KmValueParameter
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
+import javax.lang.model.element.ElementKind
 import javax.lang.model.type.TypeMirror
 
 /**
@@ -144,4 +146,38 @@ fun TypeName.typeArguments(): List<TypeName> {
     } else {
         emptyList()
     }
+}
+
+/**
+ * Convenience function to retrieve an [Annotation] from an [Element] by either getting it directly
+ * from the [Element] if it is a [ElementKind.CLASS] or getting it from the [ProcessingEnvironment].
+ */
+inline fun <reified T : Annotation> Element.annotation(env: ProcessingEnvironment): T? = if (kind == ElementKind.CLASS) {
+    getAnnotation(T::class.java)
+} else {
+    env.elementUtils.getTypeElement(asType().toString()).getAnnotation(T::class.java)
+}
+
+/**
+ * Convenience function to retrieve the class name of an [Element] by either getting it directly
+ * from the [Element] if it is a [ElementKind.CLASS] or getting it from the [ProcessingEnvironment].
+ */
+fun Element.className(env: ProcessingEnvironment) = if (kind == ElementKind.CLASS) {
+    getName()
+} else {
+    env.elementUtils.getTypeElement(asType().toString()).getName()
+}
+
+/**
+ * Convenience function to retrieve the [ElementKind.METHOD] [Element]s from an [Element] by either
+ * getting it directly from the [Element] if it is a [ElementKind.CLASS] or getting it from the
+ * [ProcessingEnvironment].
+ */
+fun Element.methodElements(env: ProcessingEnvironment): List<Element> {
+    val elements = if (kind == ElementKind.CLASS) {
+        enclosedElements
+    } else {
+        env.elementUtils.getTypeElement(asType().toString()).enclosedElements
+    }
+    return elements.filter { it.kind == ElementKind.METHOD }
 }

--- a/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -2,6 +2,7 @@ package com.salesforce.nimbus.bridge.v8.compiler
 
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.compiler.BinderGenerator
+import com.salesforce.nimbus.compiler.annotation
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
 import com.salesforce.nimbus.compiler.asTypeName
@@ -19,6 +20,7 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmValueParameter
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.VariableElement
@@ -41,8 +43,8 @@ class V8BinderGenerator : BinderGenerator() {
     private val v8FunctionClassName = ClassName(v8Package, "V8Function")
     private val k2V8ClassName = ClassName(k2v8Package, "K2V8")
 
-    override fun shouldGenerateBinder(pluginElement: Element): Boolean {
-        return pluginElement.getAnnotation(PluginOptions::class.java).supportsV8
+    override fun shouldGenerateBinder(environment: ProcessingEnvironment, pluginElement: Element): Boolean {
+        return pluginElement.annotation<PluginOptions>(processingEnv)!!.supportsV8
     }
 
     override fun processClassProperties(builder: TypeSpec.Builder) {

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -2,6 +2,7 @@ package com.salesforce.nimbus.bridge.webview.compiler
 
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.compiler.BinderGenerator
+import com.salesforce.nimbus.compiler.annotation
 import com.salesforce.nimbus.compiler.asKotlinTypeName
 import com.salesforce.nimbus.compiler.asRawTypeName
 import com.salesforce.nimbus.compiler.asTypeName
@@ -21,6 +22,7 @@ import com.squareup.kotlinpoet.asTypeName
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
+import javax.annotation.processing.ProcessingEnvironment
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.VariableElement
@@ -40,8 +42,8 @@ class WebViewBinderGenerator : BinderGenerator() {
     private val toJSONEncodableFunctionName = ClassName(nimbusPackage, "toJSONEncodable")
     private val kotlinJSONEncodableClassName = ClassName(nimbusPackage, "KotlinJSONEncodable")
 
-    override fun shouldGenerateBinder(pluginElement: Element): Boolean {
-        return pluginElement.getAnnotation(PluginOptions::class.java).supportsWebView
+    override fun shouldGenerateBinder(environment: ProcessingEnvironment, pluginElement: Element): Boolean {
+        return pluginElement.annotation<PluginOptions>(processingEnv)!!.supportsWebView
     }
 
     override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {

--- a/platforms/android/modules/core-plugins/build.gradle.kts
+++ b/platforms/android/modules/core-plugins/build.gradle.kts
@@ -11,16 +11,10 @@ android {
 }
 
 dependencies {
-    compileOnly(nimbusModule("core"))
-    compileOnly(nimbusModule("annotations"))
-    compileOnly(nimbusModule("bridge-webview"))
-    compileOnly(nimbusModule("bridge-v8"))
-    api(Libs.kotlinStdlib)
+    implementation(nimbusModule("core"))
+    implementation(nimbusModule("annotations"))
+    implementation(Libs.kotlinStdlib)
     compileOnly(Libs.kotlinxSerializationRuntime)
-    compileOnly(Libs.j2v8)
-    compileOnly(Libs.k2v8)
-    kapt(nimbusModule("compiler-webview"))
-    kapt(nimbusModule("compiler-v8"))
 }
 
 tasks {


### PR DESCRIPTION
This PR creates a new annotation `@BoundPlugin` which allows apps to annotate library plugins (`DeviceInfoPlugin`, for example) when they are used as fields or in value parameters which will trigger binder generation for them. Previously the binders were being generated in the library which would cause transitive dependencies to be included in the consuming app. 

The consumer can declare a plugin as a class variable, like this:
```
class SomeActivity : Activity {
    @BoundPlugin 
    val plugin: SomeLibraryPlugin = SomeLibraryPlugin()
}
```
This will generate whatever binders the library supports as long as the compiler for that binder is included in the consuming app. For example, if the plugin supports both webview and v8 but the app does not include the `compiler-v8` dependency then no v8 binder will be generated. However, if the plugin does not support a bridge and the consuming app includes the compiler dependency for that binder it will also not be generated. 