### PR TITLE
CI for Pre-release builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,6 +236,24 @@ jobs:
           command: |
             github-release upload -T ${HYPE_GITHUB_TOKEN} -o ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -t ${CIRCLE_TAG} ./workspace/NimbusJS.zip
 
+  create-tagged-pre-release:
+    docker:
+      - image: circleci/node:10
+
+    steps:
+      - attach_workspace:
+          at: workspace
+
+      - run:
+          name: "Install node github release CLI"
+          command: |
+            sudo npm install -g github-release-cli
+
+      - run:
+          name: "Create GitHub Release"
+          command: |
+            github-release upload -T ${HYPE_GITHUB_TOKEN} -o ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -t ${CIRCLE_TAG} --prerelease=true ./workspace/NimbusJS.zip
+
   build-and-test-android:
     docker:
       - image: circleci/android:api-29-node
@@ -440,6 +458,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
+      - create-tagged-pre-release:
+          requires:
+            - build-and-test-ios-13
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+-beta\d+$/
       - upload-android-release:
           requires:
             - build-and-test-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -387,6 +387,19 @@ jobs:
           command: |
             ./gradlew bintrayUpload
 
+  upload-android-snapshot:
+    docker:
+      - image: circleci/android:api-29-node
+
+    steps:
+      - checkout
+
+      - run:
+          name: Build and upload Android snapshot to artifactory
+          working_directory: platforms/android
+          command: |
+            ./gradlew publishSnapshot
+
   build-docs:
     docker:
       - image: circleci/node:10
@@ -474,6 +487,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
+      - upload-android-snapshot:
+          requires:
+            - build-and-test-android
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+-beta\d+$/
 
   build-and-test:
     jobs:

--- a/platforms/android/build.gradle.kts
+++ b/platforms/android/build.gradle.kts
@@ -70,7 +70,7 @@ tasks.register("publishSnapshot") {
     }
     doLast {
         val stringVersion = version.toString()
-        val regex = "[0-9]+.[0-9]+.[0-9]+".toRegex()
+        val regex = "[0-9]+\\.[0-9]+\\.[0-9]+".toRegex()
         val numericVersion = regex.find(stringVersion)
         if (numericVersion != null) {
             version = numericVersion.value + "-SNAPSHOT"

--- a/platforms/android/build.gradle.kts
+++ b/platforms/android/build.gradle.kts
@@ -1,6 +1,7 @@
 import groovy.json.JsonSlurper
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.gradle.api.GradleException
 
 buildscript {
     repositories {
@@ -56,6 +57,26 @@ tasks {
         subProjects = listOf("core", "core-plugins", "bridge-webview", "bridge-v8")
         configuration {
             moduleName = "nimbus"
+        }
+    }
+}
+
+tasks.register("publishSnapshot") {
+    val publishTask = tasks.findByPath("artifactoryPublish")
+    if (publishTask != null) {
+        this.finalizedBy(publishTask)
+    } else {
+        throw GradleException("Unable to find the publish task")
+    }
+    doLast {
+        val stringVersion = version.toString()
+        val regex = "[0-9]+.[0-9]+.[0-9]+".toRegex()
+        val numericVersion = regex.find(stringVersion)
+        if (numericVersion != null) {
+            version = numericVersion.value + "-SNAPSHOT"
+        } else {
+            logger.error("Version in project is invalid")
+            throw GradleException("Version in project is invalid")
         }
     }
 }

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -920,7 +920,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)(.)*\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
 		};
 		CC131168242571DE002D698D /* Set Version */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/platforms/apple/Nimbus.xcodeproj/project.pbxproj
+++ b/platforms/apple/Nimbus.xcodeproj/project.pbxproj
@@ -920,7 +920,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)(.)*\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+.[0-9]+.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
+			shellScript = "FULL_VERSION=\"$(grep -Ei '\\\"version\\\": \\\"([.0-9]+)(.)*\\\"' ../../lerna.json)\"\nVERSION=\"$(echo ${FULL_VERSION}\\ | grep -E -o '[0-9]+\\.[0-9]+\\.[0-9]+')\"\n\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString ${VERSION}\" $BUILT_PRODUCTS_DIR/$INFOPLIST_PATH\n";
 		};
 		CC131168242571DE002D698D /* Set Version */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
This adds two new tasks to the circle ci config, both only triggered by a tag push where the tag matches something that looks like `major.minor.patch-beta(beta number)`.

One for iOS which uploads a release to GitHub for the given tag, marked as pre-release.

One that calls a new Android gradle task that massages the project version to append `-SNAPSHOT` and cut out any beta strings and then calls the `artifactoryPublish` task to upload a snapshot.