### PR TITLE
Android promise error handling

### DIFF
--- a/packages/nimbus-bridge/src/index.ts
+++ b/packages/nimbus-bridge/src/index.ts
@@ -131,15 +131,17 @@ let promisify = (src: any): void => {
     let func = src[key];
     dest[key] = (...args: any[]): Promise<any> => {
       args = cloneArguments(args);
-      try {
-        let result = func.call(src, ...args);
-        if (result !== undefined) {
-          result = JSON.parse(result);
+
+      return new Promise(function(resolve, reject): void {
+        var promiseId = uuidv4();
+        uuidsToPromises[promiseId] = { resolve, reject };
+        try {
+          func.call(src, JSON.stringify({ promiseId }), ...args);
+        } catch (error) {
+          delete uuidsToPromises[promiseId];
+          reject(error);
         }
-        return Promise.resolve(result);
-      } catch (error) {
-        return Promise.reject(error);
-      }
+      });
     };
   });
   return dest;

--- a/packages/test-www/test/nimbus-core-tests.ts
+++ b/packages/test-www/test/nimbus-core-tests.ts
@@ -62,18 +62,18 @@ describe("Nimbus JS API", () => {
   });
   // This test is temporarily disabled until Android Array/List implementation is fixed
   // Test a binding of a nullary function that resolves to an array of Integers
-  // it("nullary function resolving to Int array", (done) => {
-  //   __nimbus.plugins.jsapiTestPlugin
-  //     .nullaryResolvingToIntArray()
-  //     .then((value: Array<number>) => {
-  //       expect(value).to.be.an("array", "result should be an array");
-  //       expect(value.length).to.deep.equal(3);
-  //       expect(value[0]).to.deep.equal(1);
-  //       expect(value[1]).to.deep.equal(2);
-  //       expect(value[2]).to.deep.equal(3);
-  //       done();
-  //     });
-  // });
+  it("nullary function resolving to Int array", (done) => {
+    __nimbus.plugins.jsapiTestPlugin
+      .nullaryResolvingToIntArray()
+      .then((value: Array<number>) => {
+        expect(value).to.be.an("array", "result should be an array");
+        expect(value.length).to.deep.equal(3);
+        expect(value[0]).to.deep.equal(1);
+        expect(value[1]).to.deep.equal(2);
+        expect(value[2]).to.deep.equal(3);
+        done();
+      });
+  });
   // Test a binding of a nullary function that resolves to an object
   it("nullary function resolving to an object", (done) => {
     __nimbus.plugins.jsapiTestPlugin

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -595,3 +595,42 @@ function unsubscribeFromStructEvent() {
   __nimbus.plugins.testPlugin.removeListener(listenerID);
   __nimbus.plugins.expectPlugin.ready();
 }
+
+// endregion
+
+// region exceptions
+
+function verifyPromiseResolvesWithNonEncodableException() {
+  __nimbus.plugins.testPlugin.promiseResolvesWithNonEncodableException().then((data) => {
+
+  }).catch((error) => {
+    if (error === "This is the exception message") {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyPromiseResolvesWithEncodableException1() {
+  __nimbus.plugins.testPlugin.promiseResolvesWithEncodableException(1).then((data) => {
+
+  }).catch((error) => {
+    if (error.code === 1 && error.message === "Encodable exception 1") {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyPromiseResolvesWithEncodableException2() {
+  __nimbus.plugins.testPlugin.promiseResolvesWithEncodableException(2).then((data) => {
+
+  }).catch((error) => {
+    if (error.code === 2 && error.message === "Encodable exception 2") {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+// endregion

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -29,6 +29,7 @@ import com.salesforce.nimbus.bridge.webview.WebViewBridge
 import com.salesforce.nimbus.bridge.webview.bridge
 import com.salesforce.nimbus.core.plugins.DeviceInfoPlugin
 import kotlinx.serialization.Serializable
+import java.lang.RuntimeException
 
 class MainActivity : AppCompatActivity() {
 
@@ -51,6 +52,7 @@ class MainActivity : AppCompatActivity() {
         val logPlugin = LogPlugin()
         val toastPlugin = ToastPlugin(this)
         val eventPlugin = EventPlugin()
+        val exceptionPlugin = ExceptionPlugin()
 
         // create the web view bridge
         webViewBridge = webView.bridge {
@@ -58,6 +60,7 @@ class MainActivity : AppCompatActivity() {
             bind { logPlugin.webViewBinder() }
             bind { toastPlugin.webViewBinder() }
             bind { eventPlugin.webViewBinder() }
+            bind { exceptionPlugin.webViewBinder() }
         }
 
         // load the demo url
@@ -72,6 +75,7 @@ class MainActivity : AppCompatActivity() {
             bind { logPlugin.v8Binder() }
             bind { toastPlugin.v8Binder() }
             bind { eventPlugin.v8Binder() }
+            bind { exceptionPlugin.v8Binder() }
         }
 
         // execute a script to get the device info plugin and then log to the console
@@ -89,6 +93,30 @@ class MainActivity : AppCompatActivity() {
 
                 __nimbus.plugins.EventPlugin.addListener("toastEvent", (event) => {
                     __nimbus.plugins.ToastPlugin.toast("V8: " + event.message);
+                });
+
+                __nimbus.plugins.ExceptionPlugin.throwException(true).then((data) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwException() returned data:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(data));
+                }).catch((error) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwException() returned error:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(error));
+                });
+
+                __nimbus.plugins.ExceptionPlugin.throwSerializableException(1).then((data) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwSerializableException() returned data:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(data));
+                }).catch((error) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwSerializableException() returned error:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(error));
+                });
+
+                __nimbus.plugins.ExceptionPlugin.throwSerializableException().then((data) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwSerializableException() returned data:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(data));
+                }).catch((error) => {
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", "ExceptionPlugin.throwSerializableException() returned error:");
+                    __nimbus.plugins.LogPlugin.debug("ExceptionPlugin", JSON.stringify(error));
                 });
             """.trimIndent()
         )
@@ -146,3 +174,32 @@ sealed class MessageEvents : Event {
 
 @PluginOptions("EventPlugin")
 class EventPlugin : Plugin, EventPublisher<MessageEvents> by DefaultEventPublisher()
+
+@Serializable
+class SerializableException1(val code: Int, override val message: String) : RuntimeException("$code, $message")
+
+@Serializable
+class SerializableException2(val code: Int, override val message: String) : RuntimeException("$code, $message")
+
+
+@PluginOptions("ExceptionPlugin")
+class ExceptionPlugin : Plugin {
+
+    @BoundMethod
+    fun throwException(throwException: Boolean): String {
+        return if (throwException) {
+            throw Exception("This is the exception")
+        } else {
+            "This is the return value"
+        }
+    }
+
+    @BoundMethod(SerializableException1::class, SerializableException2::class)
+    fun throwSerializableException(value: Int): String {
+        when (value) {
+            1 -> throw SerializableException1(1, "SerializableException1")
+            2 -> throw SerializableException2(2, "SerializableException2")
+            else -> return "This is the return value"
+        }
+    }
+}

--- a/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
+++ b/platforms/android/demo-app/src/main/java/com/salesforce/nimbusdemoapp/MainActivity.kt
@@ -194,7 +194,7 @@ class ExceptionPlugin : Plugin {
         }
     }
 
-    @BoundMethod(SerializableException1::class, SerializableException2::class)
+    @BoundMethod(throwsExceptions = [SerializableException1::class, SerializableException2::class])
     fun throwSerializableException(value: Int): String {
         when (value) {
             1 -> throw SerializableException1(1, "SerializableException1")

--- a/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundMethod.kt
+++ b/platforms/android/modules/annotations/src/main/java/com/salesforce/nimbus/BoundMethod.kt
@@ -1,5 +1,7 @@
 package com.salesforce.nimbus
 
+import kotlin.reflect.KClass
+
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
-annotation class BoundMethod
+annotation class BoundMethod(vararg val throwsExceptions: KClass<out Throwable> = [])

--- a/platforms/android/modules/bridge-v8/src/main/java/com/salesforce/nimbus/bridge/v8/V8Extensions.kt
+++ b/platforms/android/modules/bridge-v8/src/main/java/com/salesforce/nimbus/bridge/v8/V8Extensions.kt
@@ -40,10 +40,14 @@ fun V8.resolvePromise(result: Any): V8Object {
 /**
  * Rejects a Promise with the [error].
  */
-fun V8.rejectPromise(error: String): V8Object {
+fun V8.rejectPromise(error: Any): V8Object {
     return promiseGlobal().executeObjectFunction(
         "reject",
-        V8Array(this).push(error)
+        if (error is List<*>) {
+            error.toV8Array(this)
+        } else {
+            V8Array(this).push(error)
+        }
     )
 }
 

--- a/platforms/android/modules/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewBridge.kt
+++ b/platforms/android/modules/bridge-webview/src/main/java/com/salesforce/nimbus/bridge/webview/WebViewBridge.kt
@@ -95,6 +95,9 @@ class WebViewBridge : Bridge<WebView, String>,
                 promise = Promise.reject(error);
             }
             promise.then((value) => {
+                if (value === undefined) {
+                    value = null;
+                }
                 _nimbus.resolvePromise("$promiseId", JSON.stringify({value: value}));
             }).catch((err) => {
                 _nimbus.rejectPromise("$promiseId", err.toString());

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -30,7 +30,6 @@ import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Types
 import javax.tools.Diagnostic
 
-
 const val salesforceNamespace = "com.salesforce"
 const val nimbusPackage = "$salesforceNamespace.nimbus"
 

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -404,7 +404,7 @@ abstract class BinderGenerator : AbstractProcessor() {
     }
 
     protected fun TypeMirror.isUnitType(): Boolean {
-        return (asKotlinTypeName() as ClassName).simpleName == "Unit"
+        return asKotlinTypeName() is ClassName && (asKotlinTypeName() as ClassName).simpleName == "Unit"
     }
 
     protected fun TypeMirror.isArrayType(): Boolean {

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -24,10 +24,12 @@ import javax.lang.model.SourceVersion
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
 import javax.lang.model.element.TypeElement
+import javax.lang.model.type.MirroredTypesException
 import javax.lang.model.type.TypeKind
 import javax.lang.model.type.TypeMirror
 import javax.lang.model.util.Types
 import javax.tools.Diagnostic
+
 
 const val salesforceNamespace = "com.salesforce"
 const val nimbusPackage = "$salesforceNamespace.nimbus"
@@ -407,5 +409,18 @@ abstract class BinderGenerator : AbstractProcessor() {
 
     protected fun TypeMirror.isArrayType(): Boolean {
         return kind == TypeKind.ARRAY
+    }
+
+    protected fun BoundMethod.getExceptions(): List<TypeMirror> {
+        try {
+
+            // this for some reason throws a MirroredTypesException
+            throwsExceptions
+        } catch (exception: MirroredTypesException) {
+
+            // but you can access the types from here
+            return exception.typeMirrors
+        }
+        return emptyList()
     }
 }

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -16,10 +16,8 @@ import com.salesforce.nimbus.compiler.typeArguments
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.asClassName
-import com.squareup.kotlinpoet.asTypeName
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -1,5 +1,6 @@
 package com.salesforce.nimbus.bridge.webview.compiler
 
+import com.salesforce.nimbus.BoundMethod
 import com.salesforce.nimbus.PluginOptions
 import com.salesforce.nimbus.compiler.BinderGenerator
 import com.salesforce.nimbus.compiler.annotation
@@ -39,8 +40,13 @@ class WebViewBinderGenerator : BinderGenerator() {
 
     private val jsonObjectClassName = ClassName("org.json", "JSONObject")
 
+    private val jsEncodableClassName = ClassName(
+        nimbusPackage,
+        "JSEncodable"
+    ).parameterizedBy(serializedOutputType).nullable(true)
     private val toJSONEncodableFunctionName = ClassName(nimbusPackage, "toJSONEncodable")
     private val kotlinJSONEncodableClassName = ClassName(nimbusPackage, "KotlinJSONEncodable")
+    private val primitiveJSONEncodableClassName = ClassName(nimbusPackage, "PrimitiveJSONEncodable")
 
     override fun shouldGenerateBinder(environment: ProcessingEnvironment, pluginElement: Element): Boolean {
         return pluginElement.annotation<PluginOptions>(processingEnv)!!.supportsWebView
@@ -63,6 +69,8 @@ class WebViewBinderGenerator : BinderGenerator() {
         kotlinFunction: KmFunction?
     ): FunSpec {
         val functionName = functionElement.simpleName.toString()
+        val returnType = functionElement.returnType
+        val hasReturnValue = !returnType.isUnitType()
 
         // try to find the fun from the kotlin class metadata to see if the
         // return type is nullable
@@ -73,6 +81,19 @@ class WebViewBinderGenerator : BinderGenerator() {
 
             // add android @JavascriptInterface annotation to function
             addAnnotation(ClassName("android.webkit", "JavascriptInterface"))
+        }
+
+        // if the function has a return value we will add a promiseId arg
+        if (hasReturnValue) {
+            funSpec.addParameter(
+                "promiseMetadata",
+                String::class
+            )
+            funSpec.addStatement(
+                "val promiseId = %T(promiseMetadata).getString(\"promiseId\")",
+                jsonObjectClassName
+            )
+            funSpec.beginControlFlow("try")
         }
 
         val funArgs = mutableListOf<String>()
@@ -143,61 +164,148 @@ class WebViewBinderGenerator : BinderGenerator() {
             funArgs.add(parameter.getName())
         }
 
-        // JSON Encode the return value if necessary
         val argsString = funArgs.joinToString(", ")
-        val returnType = functionElement.returnType
-        when (returnType.kind) {
-            TypeKind.VOID -> processVoidReturnType(functionElement, argsString, kotlinReturnType, funSpec)
-            TypeKind.DECLARED -> {
-                when {
-                    returnType.isStringType() -> processStringReturnType(
-                        functionElement,
-                        argsString,
-                        kotlinReturnType,
-                        funSpec
-                    )
-                    returnType.isListType() -> processListReturnType(
-                        functionElement,
-                        returnType as DeclaredType,
-                        argsString,
-                        funSpec
-                    )
-                    returnType.isMapType() -> processMapReturnType(
-                        functionElement,
-                        returnType as DeclaredType,
-                        argsString,
-                        funSpec
-                    )
-                    returnType.isJSONEncodableType() -> processJSONEncodableReturnType(
-                        functionElement,
-                        argsString,
-                        funSpec
-                    )
-                    returnType.isKotlinSerializableType() -> processKotlinSerializableReturnType(
-                        functionElement,
-                        argsString,
-                        funSpec
-                    )
-                    else -> processOtherDeclaredReturnType(
-                        functionElement,
-                        argsString,
-                        kotlinReturnType,
-                        funSpec
+        if (hasReturnValue) {
+            when (returnType.kind) {
+                TypeKind.DECLARED -> {
+                    when {
+                        returnType.isStringType() -> processStringReturnType(
+                            functionElement,
+                            argsString,
+                            kotlinReturnType,
+                            funSpec
+                        )
+                        returnType.isListType() -> processListReturnType(
+                            functionElement,
+                            returnType as DeclaredType,
+                            argsString,
+                            funSpec
+                        )
+                        returnType.isMapType() -> processMapReturnType(
+                            functionElement,
+                            returnType as DeclaredType,
+                            argsString,
+                            funSpec
+                        )
+                        returnType.isJSONEncodableType() -> processJSONEncodableReturnType(
+                            functionElement,
+                            argsString,
+                            funSpec
+                        )
+                        returnType.isKotlinSerializableType() -> processKotlinSerializableReturnType(
+                            functionElement,
+                            argsString,
+                            funSpec
+                        )
+                        else -> processOtherDeclaredReturnType(
+                            functionElement,
+                            argsString,
+                            kotlinReturnType,
+                            funSpec
+                        )
+                    }
+                }
+                TypeKind.ARRAY -> processArrayReturnType(
+                    functionElement,
+                    argsString,
+                    funSpec
+                )
+                else -> {
+                    funSpec.addStatement(
+                        "val result = %T(target.%N($argsString))",
+                        primitiveJSONEncodableClassName,
+                        functionElement.simpleName.toString()
                     )
                 }
             }
-            TypeKind.ARRAY -> processArrayReturnType(
-                functionElement,
-                argsString,
-                funSpec
-            )
-            else -> {
-                // TODO: we should whitelist types we know work rather than just hoping for the best
+
+            funSpec.addCode(CodeBlock.Builder().apply {
+                addStatement(
+                    "val args = arrayOf<%T>(",
+                    jsEncodableClassName
+                )
+                indent()
+                addStatement(
+                    "%T(promiseId),",
+                    primitiveJSONEncodableClassName
+                )
+                addStatement("result,")
+                addStatement("null")
+                unindent()
+                addStatement(")")
+                addStatement(
+                    "runtime?.invoke(%S, %N, null)",
+                    "__nimbus.resolvePromise",
+                    "args"
+                )
+            }.build())
+
+            funSpec.nextControlFlow("catch (throwable: Throwable)")
+
+            val exceptions = functionElement.getAnnotation(BoundMethod::class.java)
+                ?.getExceptions() ?: emptyList()
+
+            // TODO do we need to do this if callback based?
+
+            // if we have any exceptions we will check if they are serializable
+            if (exceptions.isNotEmpty()) {
+                funSpec.addCode(
+                    CodeBlock.Builder().apply {
+                        addStatement("val error = when (throwable) {")
+                        indent()
+                        exceptions.filter { it.isKotlinSerializableType() }.forEach { exception ->
+                            addStatement(
+                                "is %T -> %T(throwable, %T.%T())",
+                                exception,
+                                kotlinJSONEncodableClassName,
+                                exception,
+                                serializerFunctionName
+                            )
+                        }
+                        addStatement(
+                            "else -> %T(throwable.message ?: \"Error\")",
+                            primitiveJSONEncodableClassName
+                        )
+                        unindent()
+                        addStatement("}")
+                    }.build()
+                )
+            } else {
                 funSpec.addStatement(
-                    "return target.%N($argsString)",
-                    functionElement.simpleName.toString()
-                ).returns(returnType.asKotlinTypeName())
+                    "val error = %T(throwable.message ?: \"Error\")",
+                    primitiveJSONEncodableClassName
+                )
             }
+
+            funSpec.addCode(
+                CodeBlock.Builder().apply {
+                    addStatement(
+                        "val args = arrayOf<%T>(",
+                        ClassName(
+                            nimbusPackage,
+                            "JSEncodable"
+                        ).parameterizedBy(serializedOutputType).nullable(true)
+                    )
+                    indent()
+                    addStatement(
+                        "%T(promiseId),",
+                        primitiveJSONEncodableClassName
+                    )
+                    addStatement("null,")
+                    addStatement("error")
+                    unindent()
+                    addStatement(")")
+                    addStatement(
+                        "runtime?.invoke(%S, %N, null)",
+                        "__nimbus.resolvePromise",
+                        "args"
+                    )
+                }.build()
+            )
+
+            funSpec.endControlFlow()
+        } else {
+            processVoidReturnType(functionElement, argsString, kotlinReturnType, funSpec)
         }
 
         return funSpec.build()
@@ -280,10 +388,7 @@ class WebViewBinderGenerator : BinderGenerator() {
             .indent()
             .add(
                 "%T(%NId),\n",
-                ClassName(
-                    nimbusPackage,
-                    "PrimitiveJSONEncodable"
-                ),
+                primitiveJSONEncodableClassName,
                 parameter.simpleName
             )
 
@@ -304,10 +409,7 @@ class WebViewBinderGenerator : BinderGenerator() {
                     } else {
                         "%T(arg$index)"
                     },
-                    ClassName(
-                        nimbusPackage,
-                        "PrimitiveJSONEncodable"
-                    )
+                    primitiveJSONEncodableClassName
                 )
             }
 
@@ -476,10 +578,7 @@ class WebViewBinderGenerator : BinderGenerator() {
             .indent()
             .add(
                 "%T(%NId)\n",
-                ClassName(
-                    nimbusPackage,
-                    "PrimitiveJSONEncodable"
-                ),
+                primitiveJSONEncodableClassName,
                 parameter.simpleName
             )
             .unindent()
@@ -641,7 +740,6 @@ class WebViewBinderGenerator : BinderGenerator() {
                 "target.%N($argsString)",
                 functionElement.simpleName.toString()
             )
-            returns(functionElement.returnType.asKotlinTypeName(nullable = kotlinReturnType.isNullable()))
         }
     }
 
@@ -653,11 +751,10 @@ class WebViewBinderGenerator : BinderGenerator() {
     ) {
         funSpec.apply {
             addStatement(
-                "return %T.quote(target.%N($argsString))",
-                jsonObjectClassName,
+                "val result = %T(target.%N($argsString))",
+                primitiveJSONEncodableClassName,
                 functionElement.simpleName.toString()
             )
-            returns(functionElement.returnType.asKotlinTypeName(nullable = kotlinReturnType.isNullable()))
         }
     }
 
@@ -672,16 +769,13 @@ class WebViewBinderGenerator : BinderGenerator() {
             parameterType.isKotlinSerializableType() -> {
                 funSpec.apply {
                     addStatement(
-                        "val json = %T(%T).stringify(%T(%T.%T()), target.%N($argsString))",
-                        jsonSerializationClassName,
-                        jsonSerializationConfigurationClassName,
+                        "val result = %T(target.%N($argsString), %T(%T.%T()))",
+                        kotlinJSONEncodableClassName,
+                        functionElement.getName(),
                         listSerializerClassName,
                         parameterType.asKotlinTypeName(),
-                        serializerFunctionName,
-                        functionElement.getName()
+                        serializerFunctionName
                     )
-                    addStatement("return json")
-                    returns(String::class)
                 }
             }
             else -> {
@@ -689,12 +783,10 @@ class WebViewBinderGenerator : BinderGenerator() {
                     addCode(
                         CodeBlock.Builder().apply {
                             addStatement(
-                                "val json = target.%N($argsString).%T().encode()",
+                                "val result = target.%N($argsString).%T()",
                                 functionElement.getName(),
                                 toJSONEncodableFunctionName
                             )
-                            addStatement("return json")
-                            returns(String::class)
                         }.build()
                     )
                 }
@@ -712,16 +804,13 @@ class WebViewBinderGenerator : BinderGenerator() {
             arrayType.isKotlinSerializableType() -> {
                 funSpec.apply {
                     addStatement(
-                        "val json = %T(%T).stringify(%T(%T.%T()), target.%N($argsString))",
-                        jsonSerializationClassName,
-                        jsonSerializationConfigurationClassName,
+                        "val result = %T(target.%N($argsString), %T(%T.%T()))",
+                        kotlinJSONEncodableClassName,
+                        functionElement.getName(),
                         arraySerializerClassName,
                         arrayType,
-                        serializerFunctionName,
-                        functionElement.getName()
+                        serializerFunctionName
                     )
-                    addStatement("return json")
-                    returns(String::class)
                 }
             }
             else -> {
@@ -729,12 +818,10 @@ class WebViewBinderGenerator : BinderGenerator() {
                     addCode(
                         CodeBlock.Builder().apply {
                             addStatement(
-                                "val json = target.%N($argsString).%T().encode()",
+                                "val result = target.%N($argsString).%T()",
                                 functionElement.getName(),
                                 toJSONEncodableFunctionName
                             )
-                            addStatement("return json")
-                            returns(String::class)
                         }.build()
                     )
                 }
@@ -761,18 +848,15 @@ class WebViewBinderGenerator : BinderGenerator() {
             valueParameterType.isKotlinSerializableType() -> {
                 funSpec.apply {
                     addStatement(
-                        "val json = %T(%T).stringify(%T(%T.%T(), %T.%T()), target.%N($argsString))",
-                        jsonSerializationClassName,
-                        jsonSerializationConfigurationClassName,
+                        "val result = %T(target.%N($argsString), %T(%T.%T(), %T.%T()))",
+                        kotlinJSONEncodableClassName,
+                        functionElement.getName(),
                         mapSerializerClassName,
                         keyParameterType.asKotlinTypeName(),
                         serializerFunctionName,
                         valueParameterType.asKotlinTypeName(),
-                        serializerFunctionName,
-                        functionElement.getName()
+                        serializerFunctionName
                     )
-                    addStatement("return json")
-                    returns(String::class)
                 }
             }
             else -> {
@@ -780,12 +864,10 @@ class WebViewBinderGenerator : BinderGenerator() {
                     addCode(
                         CodeBlock.Builder().apply {
                             addStatement(
-                                "val json = target.%N($argsString).%T().encode()",
+                                "val result = target.%N($argsString).%T()",
                                 functionElement.getName(),
                                 toJSONEncodableFunctionName
                             )
-                            addStatement("return json")
-                            returns(String::class)
                         }.build()
                     )
                 }
@@ -800,11 +882,9 @@ class WebViewBinderGenerator : BinderGenerator() {
     ) {
         funSpec.apply {
             addStatement(
-                "val json = target.%N($argsString).encode()",
+                "val result = target.%N($argsString)",
                 functionElement.getName()
             )
-            addStatement("return json")
-            returns(String::class)
         }
     }
 
@@ -815,14 +895,12 @@ class WebViewBinderGenerator : BinderGenerator() {
     ) {
         funSpec.apply {
             addStatement(
-                "val json = %T(%T).stringify(%T.serializer(), target.%N($argsString))",
-                jsonSerializationClassName,
-                jsonSerializationConfigurationClassName,
+                "val result = %T(target.%N($argsString), %T.%T())",
+                kotlinJSONEncodableClassName,
+                functionElement.getName(),
                 functionElement.returnType,
-                functionElement.getName()
+                serializerFunctionName
             )
-            addStatement("return json")
-            returns(String::class)
         }
     }
 
@@ -845,7 +923,6 @@ class WebViewBinderGenerator : BinderGenerator() {
                         type.toKotlinTypeName(nullable = nullable)
                     }
                 )
-            funSpec.returns(returnType)
         } else {
             funSpec.returns(functionElement.returnType.asKotlinTypeName(nullable = kotlinReturnType.isNullable()))
         }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -69,8 +69,32 @@ class StructEvent(val theStruct: TestStruct) : Event {
     override val name: String = "structEvent"
 }
 
+@Serializable
+class EncodableException1(val code: Int, override val message: String) : RuntimeException("$code: $message")
+
+@Serializable
+class EncodableException2(val code: Int, override val message: String) : RuntimeException("$code: $message")
+
 @PluginOptions(name = "testPlugin")
 class TestPlugin : Plugin, EventPublisher<StructEvent> by DefaultEventPublisher() {
+
+    // region exception testing
+
+    @BoundMethod
+    fun promiseResolvesWithNonEncodableException() {
+        throw Exception("This is the exception message")
+    }
+
+    @BoundMethod(EncodableException1::class, EncodableException2::class)
+    fun promiseResolvesWithEncodableException(code: Int) {
+        if (code == 1) {
+            throw EncodableException1(1, "Encodable exception 1")
+        } else if (code == 2) {
+            throw EncodableException2(2, "Encodable exception 2")
+        }
+    }
+
+    // endregion
 
     // region nullary parameters
 

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -348,6 +348,25 @@ class V8PluginTests {
 
     // endregion
 
+    // region exceptions
+
+    @Test
+    fun verifyPromiseResolvesWithNonEncodableException() {
+        executeTest("verifyPromiseResolvesWithNonEncodableException()")
+    }
+
+    @Test
+    fun verifyPromiseResolvesWithEncodableException1() {
+        executeTest("verifyPromiseResolvesWithEncodableException1()")
+    }
+
+    @Test
+    fun verifyPromiseResolvesWithEncodableException2() {
+        executeTest("verifyPromiseResolvesWithEncodableException2()")
+    }
+
+    // endregion
+
     private fun executeTest(function: String) {
         assertThat(expectPlugin.testReady.await(30, TimeUnit.SECONDS)).isTrue()
         v8.scope { v8.executeScript(function) }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewMochaTests.kt
@@ -135,8 +135,8 @@ class JSAPITestPlugin : Plugin {
     }
 
     @BoundMethod
-    fun nullaryResolvingToIntArray(): ArrayList<Int> {
-        return arrayListOf(1, 2, 3)
+    fun nullaryResolvingToIntArray(): Array<Int> {
+        return arrayOf(1, 2, 3)
     }
 
     @BoundMethod

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -412,6 +412,25 @@ class WebViewPluginTests {
 
     // endregion
 
+    // region exceptions
+
+    @Test
+    fun verifyPromiseResolvesWithNonEncodableException() {
+        executeTest("verifyPromiseResolvesWithNonEncodableException()")
+    }
+
+    @Test
+    fun verifyPromiseResolvesWithEncodableException1() {
+        executeTest("verifyPromiseResolvesWithEncodableException1()")
+    }
+
+    @Test
+    fun verifyPromiseResolvesWithEncodableException2() {
+        executeTest("verifyPromiseResolvesWithEncodableException2()")
+    }
+
+    // endregion
+
     private fun executeTest(script: String) {
         expectPlugin.testReady.withTimeoutInSeconds(30) {
             runOnUiThread { webView.evaluateJavascript(script) {} }


### PR DESCRIPTION
This PR handles properly rejecting promises in Android with exceptions that occur on the native side, adding support for `@Serializable` exceptions. For normal non-declared exceptions the promise will be resolved with the `Exception.message`. A new property has been added to `@BoundMethod` called `throwsExceptions` which allows specifying one or more exceptions that the bound method can throw. If those exceptions are `@Serializable` the promise will be resolved with the serialized exception. 

Changes were necessary to the way synchronous returns are handled in the `WebView` binders in order to allow for handling/serializing the exception. `WebView` binders no longer will return a value and instead will invoke the `__nimbus.resolvePromise()` function with either the return value or the exception. 