### PR TITLE
fix(publish) - set snapshot version when publishing snapshot

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
         "docs",
         "packages/*"
     ],
-    "version": "0.0.1-beta1"
+    "version": "2.0.0-beta1"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
         "docs",
         "packages/*"
     ],
-    "version": "2.0.0-beta1"
+    "version": "0.0.1-beta1"
 }

--- a/packages/nimbus-bridge/package-lock.json
+++ b/packages/nimbus-bridge/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nimbus-types",
-    "version": "2.0.0",
+    "version": "2.0.0-beta1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/platforms/android/modules/annotations/build.gradle.kts
+++ b/platforms/android/modules/annotations/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `maven-publish`
     id("kotlin")
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 dependencies {

--- a/platforms/android/modules/bridge-v8/build.gradle.kts
+++ b/platforms/android/modules/bridge-v8/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id("org.jetbrains.dokka")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 android {

--- a/platforms/android/modules/bridge-webview/build.gradle.kts
+++ b/platforms/android/modules/bridge-webview/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     id("org.jetbrains.dokka")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 android {

--- a/platforms/android/modules/compiler-base/build.gradle.kts
+++ b/platforms/android/modules/compiler-base/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("kotlin")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 dependencies {

--- a/platforms/android/modules/compiler-v8/build.gradle.kts
+++ b/platforms/android/modules/compiler-v8/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("kotlin")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 dependencies {

--- a/platforms/android/modules/compiler-webview/build.gradle.kts
+++ b/platforms/android/modules/compiler-webview/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     id("kotlin")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 dependencies {

--- a/platforms/android/modules/core-plugins/build.gradle.kts
+++ b/platforms/android/modules/core-plugins/build.gradle.kts
@@ -11,6 +11,9 @@ plugins {
     kotlin("plugin.serialization")
     kotlin("kapt")
     id("org.jetbrains.dokka")
+    `maven-publish`
+    id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 android {
@@ -22,4 +25,22 @@ dependencies {
     implementation(nimbusModule("annotations"))
     implementation(Libs.kotlinStdlib)
     compileOnly(Libs.kotlinxSerializationRuntime)
+}
+
+val sourcesJar by tasks.creating(Jar::class) {
+    archiveClassifier.set("sources")
+    from(android.sourceSets.getByName("main").java.srcDirs)
+}
+
+afterEvaluate {
+    publishing {
+        setupAllPublications(project)
+        publications.getByName<MavenPublication>("mavenPublication") {
+            artifact(sourcesJar)
+        }
+    }
+
+    bintray {
+        setupPublicationsUpload(project, publishing)
+    }
 }

--- a/platforms/android/modules/core/build.gradle.kts
+++ b/platforms/android/modules/core/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     id("org.jetbrains.dokka")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
 }
 
 android {

--- a/platforms/android/modules/nimbusjs/build.gradle.kts
+++ b/platforms/android/modules/nimbusjs/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     kotlin("android")
     `maven-publish`
     id("com.jfrog.bintray")
+    id("com.jfrog.artifactory")
     id("com.github.node-gradle.node") version "2.2.4"
 }
 


### PR DESCRIPTION
Fixes a bug in the publishSnapshot task that didn't set the version at the correct time in the build lifecycle, so version was staying as x.x.x-beta instead of x.x.x-SNAPSHOT