### PR TITLE
Opt in to using UnstableDefault

### DIFF
--- a/platforms/android/modules/core/build.gradle.kts
+++ b/platforms/android/modules/core/build.gradle.kts
@@ -48,3 +48,7 @@ afterEvaluate {
         setupPublicationsUpload(project, publishing)
     }
 }
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
+    kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlinx.serialization.UnstableDefault"
+}

--- a/platforms/android/modules/core/src/main/java/com/salesforce/nimbus/Constants.kt
+++ b/platforms/android/modules/core/src/main/java/com/salesforce/nimbus/Constants.kt
@@ -7,11 +7,10 @@
 
 package com.salesforce.nimbus
 
-import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.JsonConfiguration
 
 const val NIMBUS_BRIDGE = "__nimbus"
 const val NIMBUS_PLUGINS = "plugins"
 const val NIMBUS_CLASS_DISCRIMINATOR = "__type"
-@UnstableDefault
+@Suppress("EXPERIMENTAL_API_USAGE")
 val NIMBUS_JSON_CONFIGURATION = JsonConfiguration(classDiscriminator = NIMBUS_CLASS_DISCRIMINATOR)

--- a/platforms/android/modules/core/src/main/java/com/salesforce/nimbus/PrimitiveJSONEncodableExtensions.kt
+++ b/platforms/android/modules/core/src/main/java/com/salesforce/nimbus/PrimitiveJSONEncodableExtensions.kt
@@ -8,7 +8,6 @@
 package com.salesforce.nimbus
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.UnstableDefault
 import kotlinx.serialization.json.Json
 import org.json.JSONArray
 import org.json.JSONObject
@@ -32,7 +31,6 @@ class PrimitiveJSONEncodable(val value: Any) : JSONEncodable {
  * A [JSONEncodable] wrapper around an object that is [Serializable] and serialized using a
  * [KSerializer]
  */
-@UnstableDefault
 class KotlinJSONEncodable<T>(private val value: T, private val serializer: KSerializer<T>) : JSONEncodable {
     override fun encode(): String {
         return Json(NIMBUS_JSON_CONFIGURATION).stringify(serializer, value)


### PR DESCRIPTION
This PR opts in to using `UnstableDefault` at the module level so that consumers aren't forced to do so. Since the `JsonConfiguration` is more of an implementation detail we shouldn't impose the opt in requirement on consumers.