### PR TITLE
Fix null Metadata for the plugin classes.

### DIFF
--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -187,7 +187,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
         // read kotlin metadata so we can determine which types are nullable
         val kotlinClass =
-            pluginElement.getAnnotation(Metadata::class.java)?.let { metadata ->
+            pluginElement.annotation<Metadata>(processingEnv)?.let { metadata ->
                 (KotlinClassMetadata.read(
                     KotlinClassHeader(
                         metadata.kind,


### PR DESCRIPTION
- The plugin classes' metadata was not retrieved with getAnnotation call. Because of this, it was unable to determine the nullability of the fields.

- This fixes the metadata and generates nullable fields on callbacks and other function calls.