### PR TITLE
Fix null Metadata for the kotlin classes.

### DIFF
--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -358,6 +358,15 @@ function verifyNullaryResolvingToIntCallback() {
   }).then(() => { });
 }
 
+function verifyNullaryResolvingToNullableIntCallback() {
+  __nimbus.plugins.testPlugin.nullaryResolvingToNullableIntCallback((result) => {
+    if (result == null) {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  }).then(() => { });
+}
+
 function verifyNullaryResolvingToLongCallback() {
   __nimbus.plugins.testPlugin.nullaryResolvingToLongCallback((result) => {
     if (result === 2) {

--- a/platforms/android/build.gradle.kts
+++ b/platforms/android/build.gradle.kts
@@ -46,9 +46,9 @@ allprojects {
 }
 
 junitJacoco {
+    includeNoLocationClasses = false
     jacocoVersion = Versions.jacoco
     setIgnoreProjects("demo-app")
-    includeNoLocationClasses = true
     includeInstrumentationCoverageInMergedReport = true
 }
 

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -190,7 +190,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
         // read kotlin metadata so we can determine which types are nullable
         val kotlinClass =
-            pluginElement.getAnnotation(Metadata::class.java)?.let { metadata ->
+            pluginElement.annotation<Metadata>(processingEnv)?.let { metadata ->
                 (KotlinClassMetadata.read(
                     KotlinClassHeader(
                         metadata.kind,

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -270,6 +270,11 @@ class TestPlugin : Plugin, EventPublisher<StructEvent> by DefaultEventPublisher(
     }
 
     @BoundMethod
+    fun nullaryResolvingToNullableIntCallback(callback: (Int?) -> Unit) {
+        callback(null)
+    }
+
+    @BoundMethod
     fun nullaryResolvingToLongCallback(callback: (Long) -> Unit) {
         callback(2L)
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -214,6 +214,11 @@ class V8PluginTests {
     }
 
     @Test
+    fun verifyNullaryResolvingToNullableIntCallback() {
+        executeTest("verifyNullaryResolvingToNullableIntCallback()")
+    }
+
+    @Test
     fun verifyNullaryResolvingToLongCallback() {
         executeTest("verifyNullaryResolvingToLongCallback()")
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -275,6 +275,11 @@ class WebViewPluginTests {
     }
 
     @Test
+    fun verifyNullaryResolvingToNullableIntCallback() {
+        executeTest("verifyNullaryResolvingToNullableIntCallback()")
+    }
+
+    @Test
     fun verifyNullaryResolvingToLongCallback() {
         executeTest("verifyNullaryResolvingToLongCallback()")
     }


### PR DESCRIPTION
The plugin classes' metadata was not retrieved with getAnnotation call. Because of this, it was unable to determine the nullability of the fields.

This fixes the metadata and generates nullable fields on callbacks and other function calls.