### PR TITLE
fix: Generated binder extension methods now match visibility of the class being extended

### DIFF
--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -177,7 +177,7 @@ abstract class BinderGenerator : AbstractProcessor() {
         val pluginName = pluginElement.annotation<PluginOptions>(processingEnv)!!.name
         val pluginTypeName = pluginElement.asKotlinTypeName()
         // Add default class modifier as Public
-        var classModifiers = mutableSetOf<KModifier>(KModifier.PUBLIC)
+        var classModifier = KModifier.PUBLIC
 
         // get event type if plugin is an event publisher
         val eventType = types.directSupertypes((pluginElement.asType()))
@@ -225,7 +225,7 @@ abstract class BinderGenerator : AbstractProcessor() {
             }
             .map { it as ExecutableElement }
 
-        kotlinClass?.let { classModifiers = processClassModifierTypes(it) }
+        kotlinClass?.let { classModifier = processClassModifierTypes(it) }
 
         val binderClassName = ClassName(nimbusPackage, "Binder").parameterizedBy(javascriptEngine, serializedOutputType)
 
@@ -234,7 +234,7 @@ abstract class BinderGenerator : AbstractProcessor() {
 
             // the Binder implements Binder<JavascriptEngine>
             .addSuperinterface(binderClassName)
-            .addModifiers(classModifiers.asIterable())
+            .addModifiers(classModifier)
 
             // add the <PluginClass> as a constructor property
             .primaryConstructor(
@@ -439,20 +439,12 @@ abstract class BinderGenerator : AbstractProcessor() {
     }
 
 
-    protected fun processClassModifierTypes(kmClass: KmClass): MutableSet<KModifier> {
-        val classModifiers = mutableSetOf<KModifier>()
-        listOf(kmClass.flags).forEach { flag ->
-            classModifiers.add(getKotlinModifiers(flag))
-        }
-        return classModifiers
+    protected fun processClassModifierTypes(kmClass: KmClass): KModifier {
+        return getKotlinModifiers(kmClass.flags)
     }
 
-    protected fun processFunctionModifierTypes(kmFunction: KmFunction): MutableSet<KModifier> {
-        val funModifiers = mutableSetOf<KModifier>()
-        listOf(kmFunction.flags).forEach { flag ->
-            funModifiers.add(getKotlinModifiers(flag))
-        }
-        return funModifiers
+    protected fun processFunctionModifierTypes(kmFunction: KmFunction): KModifier {
+        return getKotlinModifiers(kmFunction.flags)
     }
 
     // Convert KotlinMetadata Flags to KModifiers

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -176,8 +176,6 @@ abstract class BinderGenerator : AbstractProcessor() {
         val binderTypeName = "${pluginElement.className(processingEnv)}${javascriptEngine.simpleName}Binder"
         val pluginName = pluginElement.annotation<PluginOptions>(processingEnv)!!.name
         val pluginTypeName = pluginElement.asKotlinTypeName()
-        // Add default class modifier as Public
-        var classModifier = KModifier.PUBLIC
 
         // get event type if plugin is an event publisher
         val eventType = types.directSupertypes((pluginElement.asType()))
@@ -225,7 +223,8 @@ abstract class BinderGenerator : AbstractProcessor() {
             }
             .map { it as ExecutableElement }
 
-        kotlinClass?.let { classModifier = processClassModifierTypes(it) }
+        // Add default class modifier as Public
+        val classModifier = kotlinClass?.let(::processClassModifierTypes) ?: KModifier.PUBLIC
 
         val binderClassName = ClassName(nimbusPackage, "Binder").parameterizedBy(javascriptEngine, serializedOutputType)
 

--- a/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
+++ b/platforms/android/modules/compiler-base/src/main/java/com/salesforce/nimbus/compiler/BinderGenerator.kt
@@ -438,7 +438,6 @@ abstract class BinderGenerator : AbstractProcessor() {
         return emptyList()
     }
 
-
     protected fun processClassModifierTypes(kmClass: KmClass): KModifier {
         return getKotlinModifiers(kmClass.flags)
     }
@@ -456,10 +455,9 @@ abstract class BinderGenerator : AbstractProcessor() {
             Flag.IS_PRIVATE(flag) -> KModifier.PRIVATE
             Flag.IS_OPEN(flag) -> KModifier.OPEN
             Flag.IS_SEALED(flag) -> KModifier.SEALED
-            Flag.IS_ABSTRACT(flag) ->KModifier.ABSTRACT
+            Flag.IS_ABSTRACT(flag) -> KModifier.ABSTRACT
             Flag.IS_FINAL(flag) -> KModifier.FINAL
             else -> KModifier.PUBLIC
         }
     }
-
 }

--- a/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -147,7 +147,7 @@ class V8BinderGenerator : BinderGenerator() {
     override fun createBinderExtensionFunction(pluginElement: Element, classModifiers: Set<KModifier>, binderClassName: ClassName): FunSpec {
         return FunSpec.builder("v8Binder")
             .receiver(pluginElement.asTypeName())
-            .addModifiers(classModifiers.asIterable())
+            .addModifiers(classModifiers)
             .addStatement(
                 "return %T(this)",
                 binderClassName
@@ -166,8 +166,8 @@ class V8BinderGenerator : BinderGenerator() {
         // create the binder function
         val parameters = "parameters"
 
-        // Setting Default Function modifier to Public
-        var funModifiers = KModifier.PUBLIC
+        // Setting Default Function modifier to Private for V8Binder
+        var funModifiers = KModifier.PRIVATE
         kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
 
         val funSpec = FunSpec.builder(functionName)

--- a/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -166,11 +166,12 @@ class V8BinderGenerator : BinderGenerator() {
         // create the binder function
         val parameters = "parameters"
 
-        var funModifiers = mutableSetOf<KModifier>(KModifier.PUBLIC)
+        // Setting Default Function modifier to Public
+        var funModifiers = KModifier.PUBLIC
         kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
 
         val funSpec = FunSpec.builder(functionName)
-            .addModifiers(funModifiers.asIterable())
+            .addModifiers(funModifiers)
             .addParameter(
                 parameters,
                 v8ArrayClassName

--- a/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -144,9 +144,10 @@ class V8BinderGenerator : BinderGenerator() {
         builder.addStatement("pluginBridge?.close()")
     }
 
-    override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {
+    override fun createBinderExtensionFunction(pluginElement: Element, classModifiers: Set<KModifier>, binderClassName: ClassName): FunSpec {
         return FunSpec.builder("v8Binder")
             .receiver(pluginElement.asTypeName())
+            .addModifiers(classModifiers.asIterable())
             .addStatement(
                 "return %T(this)",
                 binderClassName
@@ -164,8 +165,12 @@ class V8BinderGenerator : BinderGenerator() {
 
         // create the binder function
         val parameters = "parameters"
+
+        var funModifiers = mutableSetOf<KModifier>(KModifier.PUBLIC)
+        kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
+
         val funSpec = FunSpec.builder(functionName)
-            .addModifiers(KModifier.PRIVATE)
+            .addModifiers(funModifiers.asIterable())
             .addParameter(
                 parameters,
                 v8ArrayClassName

--- a/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
+++ b/platforms/android/modules/compiler-v8/src/main/java/com/salesforce/nimbus/bridge/v8/compiler/V8BinderGenerator.kt
@@ -167,11 +167,10 @@ class V8BinderGenerator : BinderGenerator() {
         val parameters = "parameters"
 
         // Setting Default Function modifier to Private for V8Binder
-        var funModifiers = KModifier.PRIVATE
-        kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
+        val funModifier = kotlinFunction?.let(::processFunctionModifierTypes) ?: KModifier.PRIVATE
 
         val funSpec = FunSpec.builder(functionName)
-            .addModifiers(funModifiers)
+            .addModifiers(funModifier)
             .addParameter(
                 parameters,
                 v8ArrayClassName

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -23,8 +23,9 @@ import com.salesforce.nimbus.compiler.typeArguments
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import kotlinx.metadata.KmFunction
 import kotlinx.metadata.KmType
 import kotlinx.metadata.KmValueParameter
@@ -57,9 +58,10 @@ class WebViewBinderGenerator : BinderGenerator() {
         return pluginElement.annotation<PluginOptions>(processingEnv)!!.supportsWebView
     }
 
-    override fun createBinderExtensionFunction(pluginElement: Element, binderClassName: ClassName): FunSpec {
+    override fun createBinderExtensionFunction(pluginElement: Element, classModifiers: Set<KModifier>, binderClassName: ClassName): FunSpec {
         return FunSpec.builder("webViewBinder")
             .receiver(pluginElement.asTypeName())
+            .addModifiers(classModifiers.asIterable())
             .addStatement(
                 "return %T(this)",
                 binderClassName
@@ -80,8 +82,13 @@ class WebViewBinderGenerator : BinderGenerator() {
         // return type is nullable
         val kotlinReturnType = kotlinFunction?.returnType
 
+        var funModifiers = mutableSetOf<KModifier>(KModifier.PUBLIC)
+        kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
+
         // create the binder function
         val funSpec = FunSpec.builder(functionName).apply {
+
+            addModifiers(funModifiers.asIterable())
 
             // add android @JavascriptInterface annotation to function
             addAnnotation(ClassName("android.webkit", "JavascriptInterface"))

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -83,13 +83,12 @@ class WebViewBinderGenerator : BinderGenerator() {
         val kotlinReturnType = kotlinFunction?.returnType
 
         // Set default Function modifier to Public
-        var funModifiers = KModifier.PUBLIC
-        kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
+        val funModifier = kotlinFunction?.let(::processFunctionModifierTypes) ?: KModifier.PUBLIC
 
         // create the binder function
         val funSpec = FunSpec.builder(functionName).apply {
 
-            addModifiers(funModifiers)
+            addModifiers(funModifier)
 
             // add android @JavascriptInterface annotation to function
             addAnnotation(ClassName("android.webkit", "JavascriptInterface"))

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -61,7 +61,7 @@ class WebViewBinderGenerator : BinderGenerator() {
     override fun createBinderExtensionFunction(pluginElement: Element, classModifiers: Set<KModifier>, binderClassName: ClassName): FunSpec {
         return FunSpec.builder("webViewBinder")
             .receiver(pluginElement.asTypeName())
-            .addModifiers(classModifiers.asIterable())
+            .addModifiers(classModifiers)
             .addStatement(
                 "return %T(this)",
                 binderClassName

--- a/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
+++ b/platforms/android/modules/compiler-webview/src/main/java/com/salesforce/nimbus/bridge/webview/compiler/WebViewBinderGenerator.kt
@@ -82,13 +82,14 @@ class WebViewBinderGenerator : BinderGenerator() {
         // return type is nullable
         val kotlinReturnType = kotlinFunction?.returnType
 
-        var funModifiers = mutableSetOf<KModifier>(KModifier.PUBLIC)
+        // Set default Function modifier to Public
+        var funModifiers = KModifier.PUBLIC
         kotlinFunction?.let { funModifiers = processFunctionModifierTypes(it) }
 
         // create the binder function
         val funSpec = FunSpec.builder(functionName).apply {
 
-            addModifiers(funModifiers.asIterable())
+            addModifiers(funModifiers)
 
             // add android @JavascriptInterface annotation to function
             addAnnotation(ClassName("android.webkit", "JavascriptInterface"))

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/ExpectPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/ExpectPlugin.kt
@@ -12,8 +12,9 @@ import com.salesforce.nimbus.Plugin
 import com.salesforce.nimbus.PluginOptions
 import java.util.concurrent.CountDownLatch
 
+// ExpectPlugin is marked internal so we can test with visibility other than "public"
 @PluginOptions("expectPlugin")
-class ExpectPlugin : Plugin {
+internal class ExpectPlugin : Plugin {
 
     var testReady = CountDownLatch(1)
         private set


### PR DESCRIPTION
When generating a binder for an `internal` class, the nimbus compiler generates a 'public' extension method for creating the binder. This extension method takes an instance of the plugin class as an argument, which results in a compiler failure due to exposing an internal class in a public extension method. 

This fixes the issue and now the compiler generates the binder extension method with the same visibility as the plugin class it is extending.