### PR TITLE
Test cases for parameter decoding error.

### DIFF
--- a/packages/@nimbus-js/runtime/src/nimbus.js
+++ b/packages/@nimbus-js/runtime/src/nimbus.js
@@ -65,6 +65,8 @@ var __nimbus = (function() {
         const callbackId = uuidv4();
         uuidsToCallbacks[callbackId] = args[i];
         clonedArgs.push(callbackId);
+      } else if (args[i] === null) {
+        clonedArgs.push(null);
       } else if (typeof args[i] === "object") {
         clonedArgs.push(JSON.stringify(args[i]));
       } else {

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -686,6 +686,9 @@ function verifyStringDecoderRejectsBool() {
   });
 }
 
+// TODO: This function is not tested from native iOS code yet. When a simple JSON notation object
+// {aaa:"bbb"} crosses the bridge it is first stringified. The stringified JSON object can't be
+// decoded by Swift to generic Dictionary.
 function verifyStringDecoderRejectsObject() {
   __nimbus.plugins.testPlugin.takesString({ aaa: "bbb" }).catch((error) => {
     __nimbus.plugins.expectPlugin.pass();

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -669,3 +669,175 @@ function verifyPromiseResolvesWithEncodableException2() {
 }
 
 // endregion
+
+// region decoder
+
+function verifyStringDecoderRejectsInt() {
+  __nimbus.plugins.testPlugin.takesString(5).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyStringDecoderRejectsBool() {
+  __nimbus.plugins.testPlugin.takesString(true).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyStringDecoderRejectsObject() {
+  __nimbus.plugins.testPlugin.takesString({ aaa: "bbb" }).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyStringDecoderRejectsNull() {
+  __nimbus.plugins.testPlugin.takesString(null).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyStringDecoderRejectsUndefined() {
+  var und;
+  __nimbus.plugins.testPlugin.takesString(und).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyNumberDecoderRejectsString() {
+  __nimbus.plugins.testPlugin.takesNumber("number").catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyNumberDecoderRejectsObject() {
+  __nimbus.plugins.testPlugin.takesNumber({ aaa: "bbb" }).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyNumberDecoderRejectsNull() {
+  __nimbus.plugins.testPlugin.takesNumber(null).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyNumberDecoderRejectsUndefined() {
+  var und;
+  __nimbus.plugins.testPlugin.takesNumber(und).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyBoolDecoderRejectsString() {
+  __nimbus.plugins.testPlugin.takesBool("number").catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyBoolDecoderRejectsObject() {
+  __nimbus.plugins.testPlugin.takesBool({ aaa: "bbb" }).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyBoolDecoderRejectsNull() {
+  __nimbus.plugins.testPlugin.takesBool(null).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyBoolDecoderRejectsUndefined() {
+  var und;
+  __nimbus.plugins.testPlugin.takesBool(und).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyDictionaryDecoderRejectsString() {
+  __nimbus.plugins.testPlugin.takesDictionary("test").catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyDictionaryDecoderRejectsInt() {
+  __nimbus.plugins.testPlugin.takesDictionary(5).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyDictionaryDecoderRejectsBool() {
+  __nimbus.plugins.testPlugin.takesDictionary(true).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyDictionaryDecoderRejectsNull() {
+  __nimbus.plugins.testPlugin.takesDictionary(null).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyDictionaryDecoderRejectsUndefined() {
+  var und;
+  __nimbus.plugins.testPlugin.takesDictionary(und).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyTestStructDecoderRejectsString() {
+  __nimbus.plugins.testPlugin.takesTestStruct("test").catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyTestStructDecoderRejectsInt() {
+  __nimbus.plugins.testPlugin.takesTestStruct(5).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyTestStructDecoderRejectsBool() {
+  __nimbus.plugins.testPlugin.takesTestStruct(true).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyTestStructDecoderRejectsNull() {
+  __nimbus.plugins.testPlugin.takesTestStruct(null).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+function verifyTestStructDecoderRejectsUndefined() {
+  var und;
+  __nimbus.plugins.testPlugin.takesTestStruct(und).catch((error) => {
+    __nimbus.plugins.expectPlugin.pass();
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
+// endregion

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -708,6 +708,15 @@ function verifyStringDecoderRejectsUndefined() {
   });
 }
 
+function verifyStringDecoderResolvesStringNull() {
+  __nimbus.plugins.testPlugin.takesString("null").then((result) => {
+    if (result === "null") {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
 function verifyNumberDecoderRejectsString() {
   __nimbus.plugins.testPlugin.takesNumber("number").catch((error) => {
     __nimbus.plugins.expectPlugin.pass();

--- a/platforms/apple/Sources/Nimbus/WebViewConnection.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewConnection.swift
@@ -72,32 +72,12 @@ public class WebViewConnection: Connection, CallableBinder {
                 let value = try JSONDecoder().decode(type, from: data)
                 return .success(value)
             } catch {
-                if let decodingError = error as? DecodingError {
-                    // This is a special case we need to catch&handle where the input is a string that
-                    // contains JSON but not of a particular user defined data type.
-                    if case let .typeMismatch(incomingType, context) = decodingError {
-                        if incomingType is String.Type,
-                            context.debugDescription == "Expected to decode String but found a dictionary instead." {
-                            return .failure(error)
-                        }
-                    }
-                    if #available(iOS 13, macOS 10.15, *) {
-                        // Another special case to handle where the input is null.
-                        if case .valueNotFound = decodingError {
-                            return .failure(error)
-                        }
-                    } else {
-                        if let value = value {
-                            let valueStringified = "\(value)"
-
-                            // Special case to handle where the input is null, for iOS 12 and below.
-                            if valueStringified == "null" {
-                                if case .dataCorrupted = decodingError {
-                                    return .failure(error)
-                                }
-                            }
-                        }
-                    }
+                // This is a special case we need to catch&handle where the input is a string that
+                // contains JSON but not of a particular user defined data type.
+                if let decodingError = error as? DecodingError,
+                    case let .typeMismatch(incomingType, _) = decodingError,
+                    incomingType is String.Type {
+                    return .failure(error)
                 }
             }
         }

--- a/platforms/apple/Sources/Nimbus/WebViewConnection.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewConnection.swift
@@ -67,19 +67,9 @@ public class WebViewConnection: Connection, CallableBinder {
             let string = value as? String {
             data = string.data(using: .utf8)
         }
-        if let data = data {
-            do {
-                let value = try JSONDecoder().decode(type, from: data)
-                return .success(value)
-            } catch {
-                // This is a special case we need to catch&handle where the input is a string that
-                // contains JSON but not of a particular user defined data type.
-                if let decodingError = error as? DecodingError,
-                    case let .typeMismatch(incomingType, _) = decodingError,
-                    incomingType is String.Type {
-                    return .failure(error)
-                }
-            }
+        if let data = data,
+            let value = try? JSONDecoder().decode(type, from: data) {
+            return .success(value)
         }
         if let value = value as? T {
             return .success(value)

--- a/platforms/apple/Sources/Nimbus/WebViewConnection.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewConnection.swift
@@ -81,9 +81,22 @@ public class WebViewConnection: Connection, CallableBinder {
                             return .failure(error)
                         }
                     }
-                    // Another special case to handle where the input is null.
-                    if case .valueNotFound = decodingError {
-                        return .failure(error)
+                    if #available(iOS 13, macOS 10.15, *) {
+                        // Another special case to handle where the input is null.
+                        if case .valueNotFound = decodingError {
+                            return .failure(error)
+                        }
+                    } else {
+                        if let value = value {
+                            let valueStringified = "\(value)"
+
+                            // Special case to handle where the input is null, for iOS 12 and below.
+                            if valueStringified == "null" {
+                                if case .dataCorrupted = decodingError {
+                                    return .failure(error)
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/platforms/apple/Sources/Nimbus/WebViewConnection.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewConnection.swift
@@ -75,8 +75,8 @@ public class WebViewConnection: Connection, CallableBinder {
                 if let decodingError = error as? DecodingError {
                     // This is a special case we need to catch&handle where the input is a string that
                     // contains JSON but not of a particular user defined data type.
-                    if case .typeMismatch(let incomingType, let context) = decodingError {
-                        if incomingType is String.Type &&
+                    if case let .typeMismatch(incomingType, context) = decodingError {
+                        if incomingType is String.Type,
                             context.debugDescription == "Expected to decode String but found a dictionary instead." {
                             return .failure(error)
                         }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -246,6 +246,10 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyStringDecoderRejectsUndefined()")
     }
 
+    func testVerifyStringDecoderResolvesStringNull() {
+        executeTest("verifyStringDecoderResolvesStringNull()")
+    }
+
     func testVerifyNumberDecoderRejectsString() {
         executeTest("verifyNumberDecoderRejectsString()")
     }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -226,6 +226,98 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyReturnValueStructuredError()")
     }
 
+    func testVerifyStringDecoderRejectsInt() {
+        executeTest("verifyStringDecoderRejectsInt()")
+    }
+
+    func testVerifyStringDecoderRejectsBool() {
+        executeTest("verifyStringDecoderRejectsBool()")
+    }
+
+    func testVerifyStringDecoderRejectsObject() {
+        executeTest("verifyStringDecoderRejectsObject()")
+    }
+
+    func testVerifyStringDecoderRejectsNull() {
+        executeTest("verifyStringDecoderRejectsNull()")
+    }
+
+    func testVerifyStringDecoderRejectsUndefined() {
+        executeTest("verifyStringDecoderRejectsUndefined()")
+    }
+
+    func testVerifyNumberDecoderRejectsString() {
+        executeTest("verifyNumberDecoderRejectsString()")
+    }
+
+    func testVerifyNumberDecoderRejectsObject() {
+        executeTest("verifyNumberDecoderRejectsObject()")
+    }
+
+    func testVerifyNumberDecoderRejectsNull() {
+        executeTest("verifyNumberDecoderRejectsNull()")
+    }
+
+    func testVerifyNumberDecoderRejectsUndefined() {
+        executeTest("verifyNumberDecoderRejectsUndefined()")
+    }
+
+    func testVerifyBoolDecoderRejectsString() {
+        executeTest("verifyBoolDecoderRejectsString()")
+    }
+
+    func testVerifyBoolDecoderRejectsObject() {
+        executeTest("verifyBoolDecoderRejectsObject()")
+    }
+
+    func testVerifyBoolDecoderRejectsNull() {
+        executeTest("verifyBoolDecoderRejectsNull()")
+    }
+
+    func testVerifyBoolDecoderRejectsUndefined() {
+        executeTest("verifyBoolDecoderRejectsUndefined()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsString() {
+        executeTest("verifyDictionaryDecoderRejectsString()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsInt() {
+        executeTest("verifyDictionaryDecoderRejectsInt()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsBool() {
+        executeTest("verifyDictionaryDecoderRejectsBool()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsNull() {
+        executeTest("verifyDictionaryDecoderRejectsNull()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsUndefined() {
+        executeTest("verifyDictionaryDecoderRejectsUndefined()")
+    }
+
+    func testVerifyTestStructDecoderRejectsString() {
+        executeTest("verifyTestStructDecoderRejectsString()")
+    }
+
+    func testVerifyTestStructDecoderRejectsInt() {
+        executeTest("verifyTestStructDecoderRejectsInt()")
+    }
+
+    func testVerifyTestStructDecoderRejectsBool() {
+        executeTest("verifyTestStructDecoderRejectsBool()")
+    }
+
+    func testVerifyTestStructDecoderRejectsNull() {
+        executeTest("verifyTestStructDecoderRejectsNull()")
+    }
+
+    func testVerifyTestStructDecoderRejectsUndefined() {
+        executeTest("verifyTestStructDecoderRejectsUndefined()")
+    }
+
     func testEventPublishing() {
         context.evaluateScript("subscribeToStructEvent()")
         XCTAssertTrue(expectPlugin.isReady)

--- a/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsJSCore.swift
@@ -234,10 +234,6 @@ class SharedTestsJSCore: XCTestCase {
         executeTest("verifyStringDecoderRejectsBool()")
     }
 
-    func testVerifyStringDecoderRejectsObject() {
-        executeTest("verifyStringDecoderRejectsObject()")
-    }
-
     func testVerifyStringDecoderRejectsNull() {
         executeTest("verifyStringDecoderRejectsNull()")
     }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -74,7 +74,7 @@ class TestPlugin: Plugin {
         connection.bind(takesTestStruct, as: "takesTestStruct")
     }
 
-    func takesString(stringParam: String) {}
+    func takesString(stringParam: String) -> String { return stringParam }
     func takesNumber(numberParam: Double) {}
     func takesBool(boolParam: Bool) {}
     func takesDictionary(dictionaryParam: [String: String]) {}

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -67,7 +67,18 @@ class TestPlugin: Plugin {
         connection.bind(binaryIntResolvingIntCallbackReturnsInt, as: "binaryIntResolvingIntCallbackReturnsInt")
         connection.bind(nullaryResolvingToSimpleError, as: "nullaryResolvingToSimpleError")
         connection.bind(nullaryResolvingToStructuredError, as: "nullaryResolvingToStructuredError")
+        connection.bind(takesString, as: "takesString")
+        connection.bind(takesNumber, as: "takesNumber")
+        connection.bind(takesBool, as: "takesBool")
+        connection.bind(takesDictionary, as: "takesDictionary")
+        connection.bind(takesTestStruct, as: "takesTestStruct")
     }
+
+    func takesString(stringParam: String) {}
+    func takesNumber(numberParam: Double) {}
+    func takesBool(boolParam: Bool) {}
+    func takesDictionary(dictionaryParam: [String: String]) {}
+    func takesTestStruct(testStructParam: TestStruct) {}
 
     func nullaryResolvingToInt() -> Int {
         return 5

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -248,6 +248,98 @@ class SharedTestsWebView: XCTestCase {
         executeTest("verifyReturnValueStructuredError()")
     }
 
+    func testVerifyStringDecoderRejectsInt() {
+        executeTest("verifyStringDecoderRejectsInt()")
+    }
+
+    func testVerifyStringDecoderRejectsBool() {
+        executeTest("verifyStringDecoderRejectsBool()")
+    }
+
+    func testVerifyStringDecoderRejectsObject() {
+        executeTest("verifyStringDecoderRejectsObject()")
+    }
+
+    func testVerifyStringDecoderRejectsNull() {
+        executeTest("verifyStringDecoderRejectsNull()")
+    }
+
+    func testVerifyStringDecoderRejectsUndefined() {
+        executeTest("verifyStringDecoderRejectsUndefined()")
+    }
+
+    func testVerifyNumberDecoderRejectsString() {
+        executeTest("verifyNumberDecoderRejectsString()")
+    }
+
+    func testVerifyNumberDecoderRejectsObject() {
+        executeTest("verifyNumberDecoderRejectsObject()")
+    }
+
+    func testVerifyNumberDecoderRejectsNull() {
+        executeTest("verifyNumberDecoderRejectsNull()")
+    }
+
+    func testVerifyNumberDecoderRejectsUndefined() {
+        executeTest("verifyNumberDecoderRejectsUndefined()")
+    }
+
+    func testVerifyBoolDecoderRejectsString() {
+        executeTest("verifyBoolDecoderRejectsString()")
+    }
+
+    func testVerifyBoolDecoderRejectsObject() {
+        executeTest("verifyBoolDecoderRejectsObject()")
+    }
+
+    func testVerifyBoolDecoderRejectsNull() {
+        executeTest("verifyBoolDecoderRejectsNull()")
+    }
+
+    func testVerifyBoolDecoderRejectsUndefined() {
+        executeTest("verifyBoolDecoderRejectsUndefined()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsString() {
+        executeTest("verifyDictionaryDecoderRejectsString()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsInt() {
+        executeTest("verifyDictionaryDecoderRejectsInt()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsBool() {
+        executeTest("verifyDictionaryDecoderRejectsBool()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsNull() {
+        executeTest("verifyDictionaryDecoderRejectsNull()")
+    }
+
+    func testVerifyDictionaryDecoderRejectsUndefined() {
+        executeTest("verifyDictionaryDecoderRejectsUndefined()")
+    }
+
+    func testVerifyTestStructDecoderRejectsString() {
+        executeTest("verifyTestStructDecoderRejectsString()")
+    }
+
+    func testVerifyTestStructDecoderRejectsInt() {
+        executeTest("verifyTestStructDecoderRejectsInt()")
+    }
+
+    func testVerifyTestStructDecoderRejectsBool() {
+        executeTest("verifyTestStructDecoderRejectsBool()")
+    }
+
+    func testVerifyTestStructDecoderRejectsNull() {
+        executeTest("verifyTestStructDecoderRejectsNull()")
+    }
+
+    func testVerifyTestStructDecoderRejectsUndefined() {
+        executeTest("verifyTestStructDecoderRejectsUndefined()")
+    }
+
     func testEventPublishing() {
         expectPlugin.readyExpectation = expectation(description: "ready")
         let subscribe = expectation(description: "subscribe")

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -10,8 +10,6 @@ import WebKit
 import XCTest
 @testable import Nimbus
 
-// swiftlint:disable type_body_length
-
 class SharedTestsWebView: XCTestCase {
     var webView = WKWebView()
     var bridge: WebViewBridge?
@@ -256,10 +254,6 @@ class SharedTestsWebView: XCTestCase {
 
     func testVerifyStringDecoderRejectsBool() {
         executeTest("verifyStringDecoderRejectsBool()")
-    }
-
-    func testVerifyStringDecoderRejectsObject() {
-        executeTest("verifyStringDecoderRejectsObject()")
     }
 
     func testVerifyStringDecoderRejectsNull() {

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -10,6 +10,8 @@ import WebKit
 import XCTest
 @testable import Nimbus
 
+// swiftlint:disable type_body_length
+
 class SharedTestsWebView: XCTestCase {
     var webView = WKWebView()
     var bridge: WebViewBridge?
@@ -266,6 +268,10 @@ class SharedTestsWebView: XCTestCase {
 
     func testVerifyStringDecoderRejectsUndefined() {
         executeTest("verifyStringDecoderRejectsUndefined()")
+    }
+
+    func testVerifyStringDecoderResolvesStringNull() {
+        executeTest("verifyStringDecoderResolvesStringNull()")
     }
 
     func testVerifyNumberDecoderRejectsString() {


### PR DESCRIPTION
Adding test cases for decoding error. When decoding fails, e.g. a string is passed when a number is expected, the promise in Javascript will be rejected and therefore can be handled in `catch(error => {...})`.

This PR does not unify `error` object passed to the handler in `catch` between web view and JSCore. Web view uses `DecodeError` which is our custom `Error` struct where as JSCore uses `DecodingError` that is out-of-the-box from Apple. Unification of error class is out of the scope for this work.

An edge case was discovered while working on this PR. Suppose there is a native function that is expecting a `String` parameter. Then from Javascript a simple simple Javascript object is passed instead, like `{aaa:`bbb`}`. Decoding of such parameter fails in JSCore, however, in web view, the script handler passes this Javascript object as JSON string. Combined with `try? JSONDecoder().decode(type, from: data)` where `data` is data representation of that JSON string the code was failing to detect wrong type being passed. You can see how I handle that below in `WebViewConnection.swift`. Similarly, `null` being passed was failing to be detected so I fixed that too. 