### PR TITLE
Enable native to call Javascript function without a return value.

### DIFF
--- a/platforms/apple/Sources/Nimbus/JSContextBridge.swift
+++ b/platforms/apple/Sources/Nimbus/JSContextBridge.swift
@@ -112,6 +112,22 @@ public class JSContextBridge: JSEvaluating {
         }
     }
 
+    /**
+     The implementation of the `JSEvaluating` protocol.
+
+     This overload function is used to call Javascript function that doesn't have a return value.
+     */
+    public func evaluate(
+        _ identifierPath: String,
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
+    ) {
+        let identifierSegments = identifierPath.split(separator: ".").map(String.init)
+        invoke(identifierSegments, with: args) { error, _ in
+            callback(error)
+        }
+    }
+
     var context: JSContext?
 }
 

--- a/platforms/apple/Sources/Nimbus/JSContextConnection.swift
+++ b/platforms/apple/Sources/Nimbus/JSContextConnection.swift
@@ -139,6 +139,14 @@ public class JSContextConnection: Connection, CallableBinder {
         bridge?.evaluate(identifierPath, with: args, callback: callback)
     }
 
+    public func evaluate(
+        _ identifierPath: String,
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
+    ) {
+        bridge?.evaluate(identifierPath, with: args, callback: callback)
+    }
+
     private let namespace: String
     private weak var context: JSContext?
     private var bridge: JSEvaluating?

--- a/platforms/apple/Sources/Nimbus/JSEvaluating.swift
+++ b/platforms/apple/Sources/Nimbus/JSEvaluating.swift
@@ -18,4 +18,13 @@ public protocol JSEvaluating {
         with args: [Encodable],
         callback: @escaping (Error?, R?) -> Void
     )
+
+    /**
+     Call the function described by the identifierPath with the given args. Error is passed as a parameter to the callback.
+     */
+    func evaluate(
+        _ identifierPath: String,
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
+    )
 }

--- a/platforms/apple/Sources/Nimbus/WebViewBridge.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewBridge.swift
@@ -26,7 +26,7 @@ public class WebViewBridge: NSObject, JSEvaluating {
      Invokes a Promise-returning Javascript function and call the specified
      promiseCompletion when that Promise resolves or rejects.
      */
-    func invoke<R>( // swiftlint:disable:this function_body_length
+    func invoke<R>(
         _ identifierSegments: [String],
         with args: [Encodable],
         callback: @escaping (Error?, R?) -> Void
@@ -56,15 +56,51 @@ public class WebViewBridge: NSObject, JSEvaluating {
         let idSegmentString: String
         let argString: String
         do {
-            let data = try JSONEncoder().encode(args.map(EncodableValue.value))
-            argString = String(data: data, encoding: .utf8)!
-
-            let idData = try JSONEncoder().encode(identifierSegments)
-            idSegmentString = String(data: idData, encoding: .utf8)!
+            (argString, idSegmentString) = try encodeArgsAndIdSegments(args: args, identifierSegments: identifierSegments)
         } catch {
             return callback(error, nil)
         }
 
+        evaluateJavaScript(promiseId: promiseId, idSegmentString: idSegmentString, argString: argString)
+    }
+
+    /**
+     Overloaded version of invoke that is used to call a Javascript function that doesn't have a return value.
+     */
+    func invoke(
+        _ identifierSegments: [String],
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
+    ) {
+        let promiseId = UUID().uuidString
+        promisesQueue.sync {
+            self.promises[promiseId] = { error, _ in
+                callback(error)
+            }
+        }
+
+        let idSegmentString: String
+        let argString: String
+        do {
+            (argString, idSegmentString) = try encodeArgsAndIdSegments(args: args, identifierSegments: identifierSegments)
+        } catch {
+            return callback(error)
+        }
+
+        evaluateJavaScript(promiseId: promiseId, idSegmentString: idSegmentString, argString: argString)
+    }
+
+    func encodeArgsAndIdSegments(args: [Encodable], identifierSegments: [String]) throws -> (String, String) {
+        let data = try JSONEncoder().encode(args.map(EncodableValue.value))
+        let argString = String(data: data, encoding: .utf8)!
+
+        let idData = try JSONEncoder().encode(identifierSegments)
+        let idSegmentString = String(data: idData, encoding: .utf8)!
+
+        return (argString, idSegmentString)
+    }
+
+    func evaluateJavaScript(promiseId: String, idSegmentString: String, argString: String) {
         let script = """
         {
             let idSegments = \(idSegmentString);
@@ -115,6 +151,18 @@ public class WebViewBridge: NSObject, JSEvaluating {
         _ identifierPath: String,
         with args: [Encodable],
         callback: @escaping (Error?, R?) -> Void
+    ) {
+        let identifierSegments = identifierPath.split(separator: ".").map(String.init)
+        invoke(identifierSegments, with: args, callback: callback)
+    }
+
+    /**
+     Overloaded version of evaluate that is used to call a Javascript function that doesn't have a return value.
+     */
+    public func evaluate(
+        _ identifierPath: String,
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
     ) {
         let identifierSegments = identifierPath.split(separator: ".").map(String.init)
         invoke(identifierSegments, with: args, callback: callback)

--- a/platforms/apple/Sources/Nimbus/WebViewConnection.swift
+++ b/platforms/apple/Sources/Nimbus/WebViewConnection.swift
@@ -160,6 +160,14 @@ public class WebViewConnection: Connection, CallableBinder {
         bridge?.evaluate(identifierPath, with: args, callback: callback)
     }
 
+    public func evaluate(
+        _ identifierPath: String,
+        with args: [Encodable],
+        callback: @escaping (Error?) -> Void
+    ) {
+        bridge?.evaluate(identifierPath, with: args, callback: callback)
+    }
+
     /**
      Called by the ConnectionMessageHandler when JS in the webview invokes a function of a native extension..
      */

--- a/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
+++ b/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
@@ -66,6 +66,22 @@ class CallJavascriptTests: XCTestCase, WKNavigationDelegate {
         XCTAssertTrue(returnValue)
     }
 
+    func testCallMethodWithoutReturn() throws {
+        loadWebViewAndWait()
+
+        let setup = expectation(description: "setup")
+        webView.evaluateJavaScript("function testFunction() {}") { _, _ in
+            setup.fulfill()
+        }
+        wait(for: [setup], timeout: 10)
+
+        let expect = expectation(description: "js result")
+        bridge!.invoke(["testFunction"], with: []) { _ -> Void in
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 5)
+    }
+
     func testCallNonExistingMethodReturnsAnError() {
         loadWebViewAndWait()
 
@@ -162,6 +178,17 @@ class CallJSContextTests: XCTestCase {
         XCTAssertEqual(resultValue, true)
     }
 
+    func testCallFunctionWithoutReturn() throws {
+        let expect = expectation(description: "test call function without return")
+        var error: Error?
+        bridge!.invoke(["testFunctionWithoutReturn"]) { theError, _ in
+            error = theError
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 5)
+        XCTAssertNil(error)
+    }
+
     func testCallNonExistentFunction() throws {
         let expect = expectation(description: "non existent function")
         var result: JSValue?
@@ -210,6 +237,7 @@ class CallJSContextTests: XCTestCase {
 
     let fixtureScript = """
     function testFunction() { return true; };
+    function testFunctionWithoutReturn() {};
     function testFunctionWithArgs(...args) {
       return Array.prototype.slice.apply(args);
     };

--- a/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
+++ b/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
@@ -76,10 +76,13 @@ class CallJavascriptTests: XCTestCase, WKNavigationDelegate {
         wait(for: [setup], timeout: 10)
 
         let expect = expectation(description: "js result")
-        bridge!.invoke(["testFunction"], with: []) { (_, _: Void?) -> Void in
+        var error: Error?
+        bridge!.evaluate("testFunction", with: []) { theError in
+            error = theError
             expect.fulfill()
         }
         wait(for: [expect], timeout: 5)
+        XCTAssertNil(error)
     }
 
     func testCallNonExistingMethodReturnsAnError() {
@@ -181,7 +184,7 @@ class CallJSContextTests: XCTestCase {
     func testCallFunctionWithoutReturn() throws {
         let expect = expectation(description: "test call function without return")
         var error: Error?
-        bridge!.invoke(["testFunctionWithoutReturn"]) { theError, _ in
+        bridge!.evaluate("testFunctionWithoutReturn", with: []) { theError in
             error = theError
             expect.fulfill()
         }

--- a/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
+++ b/platforms/apple/Sources/NimbusTests/CallJavascriptTests.swift
@@ -76,7 +76,7 @@ class CallJavascriptTests: XCTestCase, WKNavigationDelegate {
         wait(for: [setup], timeout: 10)
 
         let expect = expectation(description: "js result")
-        bridge!.invoke(["testFunction"], with: []) { _ -> Void in
+        bridge!.invoke(["testFunction"], with: []) { (_, _: Void?) -> Void in
             expect.fulfill()
         }
         wait(for: [expect], timeout: 5)


### PR DESCRIPTION
* Added overloaded `evaluate` method for web view bridge and JSContext bridge.
* Web view refactored to fix overloaded `evaluate`.
 