### PR TITLE
Android parameter rejection tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
     "dependencies": {
         "@babel/code-frame": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@babel/code-frame/-/code-frame-7.10.4.tgz",
             "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
             "dev": true,
             "requires": {
@@ -14,13 +14,13 @@
         },
         "@babel/helper-validator-identifier": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
             "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
             "dev": true
         },
         "@babel/highlight": {
             "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@babel/highlight/-/highlight-7.10.4.tgz",
             "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
             "dev": true,
             "requires": {
@@ -31,7 +31,7 @@
         },
         "@evocateur/libnpmaccess": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@evocateur/libnpmaccess/-/libnpmaccess-3.1.2.tgz",
             "integrity": "sha512-KSCAHwNWro0CF2ukxufCitT9K5LjL/KuMmNzSu8wuwN2rjyKHD8+cmOsiybK+W5hdnwc5M1SmRlVCaMHQo+3rg==",
             "dev": true,
             "requires": {
@@ -52,7 +52,7 @@
         },
         "@evocateur/libnpmpublish": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/@evocateur/libnpmpublish/-/libnpmpublish-1.2.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@evocateur/libnpmpublish/-/libnpmpublish-1.2.2.tgz",
             "integrity": "sha512-MJrrk9ct1FeY9zRlyeoyMieBjGDG9ihyyD9/Ft6MMrTxql9NyoEx2hw9casTIP4CdqEVu+3nQ2nXxoJ8RCXyFg==",
             "dev": true,
             "requires": {
@@ -75,7 +75,7 @@
                 },
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -83,7 +83,7 @@
         },
         "@evocateur/npm-registry-fetch": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/@evocateur/npm-registry-fetch/-/npm-registry-fetch-4.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@evocateur/npm-registry-fetch/-/npm-registry-fetch-4.0.0.tgz",
             "integrity": "sha512-k1WGfKRQyhJpIr+P17O5vLIo2ko1PFLKwoetatdduUSt/aQ4J2sJrJwwatdI5Z3SiYk/mRH9S3JpdmMFd/IK4g==",
             "dev": true,
             "requires": {
@@ -98,7 +98,7 @@
         },
         "@evocateur/pacote": {
             "version": "9.6.5",
-            "resolved": "https://registry.npmjs.org/@evocateur/pacote/-/pacote-9.6.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@evocateur/pacote/-/pacote-9.6.5.tgz",
             "integrity": "sha512-EI552lf0aG2nOV8NnZpTxNo2PcXKPmDbF9K8eCBFQdIZwHNGN/mi815fxtmUMa2wTa1yndotICIDt/V0vpEx2w==",
             "dev": true,
             "requires": {
@@ -135,7 +135,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -143,7 +143,7 @@
         },
         "@lerna/add": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/add/-/add-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/add/-/add-3.21.0.tgz",
             "integrity": "sha512-vhUXXF6SpufBE1EkNEXwz1VLW03f177G9uMOFMQkp6OJ30/PWg4Ekifuz9/3YfgB2/GH8Tu4Lk3O51P2Hskg/A==",
             "dev": true,
             "requires": {
@@ -161,7 +161,7 @@
         },
         "@lerna/bootstrap": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/bootstrap/-/bootstrap-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/bootstrap/-/bootstrap-3.21.0.tgz",
             "integrity": "sha512-mtNHlXpmvJn6JTu0KcuTTPl2jLsDNud0QacV/h++qsaKbhAaJr/FElNZ5s7MwZFUM3XaDmvWzHKaszeBMHIbBw==",
             "dev": true,
             "requires": {
@@ -192,7 +192,7 @@
         },
         "@lerna/changed": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/changed/-/changed-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/changed/-/changed-3.21.0.tgz",
             "integrity": "sha512-hzqoyf8MSHVjZp0gfJ7G8jaz+++mgXYiNs9iViQGA8JlN/dnWLI5sWDptEH3/B30Izo+fdVz0S0s7ydVE3pWIw==",
             "dev": true,
             "requires": {
@@ -204,7 +204,7 @@
         },
         "@lerna/check-working-tree": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/check-working-tree/-/check-working-tree-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/check-working-tree/-/check-working-tree-3.16.5.tgz",
             "integrity": "sha512-xWjVBcuhvB8+UmCSb5tKVLB5OuzSpw96WEhS2uz6hkWVa/Euh1A0/HJwn2cemyK47wUrCQXtczBUiqnq9yX5VQ==",
             "dev": true,
             "requires": {
@@ -215,7 +215,7 @@
         },
         "@lerna/child-process": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/child-process/-/child-process-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/child-process/-/child-process-3.16.5.tgz",
             "integrity": "sha512-vdcI7mzei9ERRV4oO8Y1LHBZ3A5+ampRKg1wq5nutLsUA4mEBN6H7JqjWOMY9xZemv6+kATm2ofjJ3lW5TszQg==",
             "dev": true,
             "requires": {
@@ -226,7 +226,7 @@
         },
         "@lerna/clean": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/clean/-/clean-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/clean/-/clean-3.21.0.tgz",
             "integrity": "sha512-b/L9l+MDgE/7oGbrav6rG8RTQvRiZLO1zTcG17zgJAAuhlsPxJExMlh2DFwJEVi2les70vMhHfST3Ue1IMMjpg==",
             "dev": true,
             "requires": {
@@ -242,7 +242,7 @@
         },
         "@lerna/cli": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/cli/-/cli-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/cli/-/cli-3.18.5.tgz",
             "integrity": "sha512-erkbxkj9jfc89vVs/jBLY/fM0I80oLmJkFUV3Q3wk9J3miYhP14zgVEBsPZY68IZlEjT6T3Xlq2xO1AVaatHsA==",
             "dev": true,
             "requires": {
@@ -254,7 +254,7 @@
         },
         "@lerna/collect-uncommitted": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/collect-uncommitted/-/collect-uncommitted-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/collect-uncommitted/-/collect-uncommitted-3.16.5.tgz",
             "integrity": "sha512-ZgqnGwpDZiWyzIQVZtQaj9tRizsL4dUOhuOStWgTAw1EMe47cvAY2kL709DzxFhjr6JpJSjXV5rZEAeU3VE0Hg==",
             "dev": true,
             "requires": {
@@ -266,7 +266,7 @@
         },
         "@lerna/collect-updates": {
             "version": "3.20.0",
-            "resolved": "https://registry.npmjs.org/@lerna/collect-updates/-/collect-updates-3.20.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/collect-updates/-/collect-updates-3.20.0.tgz",
             "integrity": "sha512-qBTVT5g4fupVhBFuY4nI/3FSJtQVcDh7/gEPOpRxoXB/yCSnT38MFHXWl+y4einLciCjt/+0x6/4AG80fjay2Q==",
             "dev": true,
             "requires": {
@@ -279,7 +279,7 @@
         },
         "@lerna/command": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/command/-/command-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/command/-/command-3.21.0.tgz",
             "integrity": "sha512-T2bu6R8R3KkH5YoCKdutKv123iUgUbW8efVjdGCDnCMthAQzoentOJfDeodBwn0P2OqCl3ohsiNVtSn9h78fyQ==",
             "dev": true,
             "requires": {
@@ -297,7 +297,7 @@
         },
         "@lerna/conventional-commits": {
             "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@lerna/conventional-commits/-/conventional-commits-3.22.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/conventional-commits/-/conventional-commits-3.22.0.tgz",
             "integrity": "sha512-z4ZZk1e8Mhz7+IS8NxHr64wyklHctCJyWpJKEZZPJiLFJ8yKto/x38O80R10pIzC0rr8Sy/OsjSH4bl0TbbgqA==",
             "dev": true,
             "requires": {
@@ -316,7 +316,7 @@
         },
         "@lerna/create": {
             "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@lerna/create/-/create-3.22.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/create/-/create-3.22.0.tgz",
             "integrity": "sha512-MdiQQzCcB4E9fBF1TyMOaAEz9lUjIHp1Ju9H7f3lXze5JK6Fl5NYkouAvsLgY6YSIhXMY8AHW2zzXeBDY4yWkw==",
             "dev": true,
             "requires": {
@@ -342,7 +342,7 @@
         },
         "@lerna/create-symlink": {
             "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@lerna/create-symlink/-/create-symlink-3.16.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/create-symlink/-/create-symlink-3.16.2.tgz",
             "integrity": "sha512-pzXIJp6av15P325sgiIRpsPXLFmkisLhMBCy4764d+7yjf2bzrJ4gkWVMhsv4AdF0NN3OyZ5jjzzTtLNqfR+Jw==",
             "dev": true,
             "requires": {
@@ -353,7 +353,7 @@
         },
         "@lerna/describe-ref": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/describe-ref/-/describe-ref-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/describe-ref/-/describe-ref-3.16.5.tgz",
             "integrity": "sha512-c01+4gUF0saOOtDBzbLMFOTJDHTKbDFNErEY6q6i9QaXuzy9LNN62z+Hw4acAAZuJQhrVWncVathcmkkjvSVGw==",
             "dev": true,
             "requires": {
@@ -363,7 +363,7 @@
         },
         "@lerna/diff": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/diff/-/diff-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/diff/-/diff-3.21.0.tgz",
             "integrity": "sha512-5viTR33QV3S7O+bjruo1SaR40m7F2aUHJaDAC7fL9Ca6xji+aw1KFkpCtVlISS0G8vikUREGMJh+c/VMSc8Usw==",
             "dev": true,
             "requires": {
@@ -375,7 +375,7 @@
         },
         "@lerna/exec": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/exec/-/exec-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/exec/-/exec-3.21.0.tgz",
             "integrity": "sha512-iLvDBrIE6rpdd4GIKTY9mkXyhwsJ2RvQdB9ZU+/NhR3okXfqKc6py/24tV111jqpXTtZUW6HNydT4dMao2hi1Q==",
             "dev": true,
             "requires": {
@@ -390,7 +390,7 @@
         },
         "@lerna/filter-options": {
             "version": "3.20.0",
-            "resolved": "https://registry.npmjs.org/@lerna/filter-options/-/filter-options-3.20.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/filter-options/-/filter-options-3.20.0.tgz",
             "integrity": "sha512-bmcHtvxn7SIl/R9gpiNMVG7yjx7WyT0HSGw34YVZ9B+3xF/83N3r5Rgtjh4hheLZ+Q91Or0Jyu5O3Nr+AwZe2g==",
             "dev": true,
             "requires": {
@@ -403,7 +403,7 @@
         },
         "@lerna/filter-packages": {
             "version": "3.18.0",
-            "resolved": "https://registry.npmjs.org/@lerna/filter-packages/-/filter-packages-3.18.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/filter-packages/-/filter-packages-3.18.0.tgz",
             "integrity": "sha512-6/0pMM04bCHNATIOkouuYmPg6KH3VkPCIgTfQmdkPJTullERyEQfNUKikrefjxo1vHOoCACDpy65JYyKiAbdwQ==",
             "dev": true,
             "requires": {
@@ -423,7 +423,7 @@
         },
         "@lerna/get-packed": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/get-packed/-/get-packed-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/get-packed/-/get-packed-3.16.0.tgz",
             "integrity": "sha512-AjsFiaJzo1GCPnJUJZiTW6J1EihrPkc2y3nMu6m3uWFxoleklsSCyImumzVZJssxMi3CPpztj8LmADLedl9kXw==",
             "dev": true,
             "requires": {
@@ -434,7 +434,7 @@
         },
         "@lerna/github-client": {
             "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@lerna/github-client/-/github-client-3.22.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/github-client/-/github-client-3.22.0.tgz",
             "integrity": "sha512-O/GwPW+Gzr3Eb5bk+nTzTJ3uv+jh5jGho9BOqKlajXaOkMYGBELEAqV5+uARNGWZFvYAiF4PgqHb6aCUu7XdXg==",
             "dev": true,
             "requires": {
@@ -464,7 +464,7 @@
         },
         "@lerna/has-npm-version": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/has-npm-version/-/has-npm-version-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/has-npm-version/-/has-npm-version-3.16.5.tgz",
             "integrity": "sha512-WL7LycR9bkftyqbYop5rEGJ9sRFIV55tSGmbN1HLrF9idwOCD7CLrT64t235t3t4O5gehDnwKI5h2U3oxTrF8Q==",
             "dev": true,
             "requires": {
@@ -474,7 +474,7 @@
         },
         "@lerna/import": {
             "version": "3.22.0",
-            "resolved": "https://registry.npmjs.org/@lerna/import/-/import-3.22.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/import/-/import-3.22.0.tgz",
             "integrity": "sha512-uWOlexasM5XR6tXi4YehODtH9Y3OZrFht3mGUFFT3OIl2s+V85xIGFfqFGMTipMPAGb2oF1UBLL48kR43hRsOg==",
             "dev": true,
             "requires": {
@@ -490,7 +490,7 @@
         },
         "@lerna/info": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/info/-/info-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/info/-/info-3.21.0.tgz",
             "integrity": "sha512-0XDqGYVBgWxUquFaIptW2bYSIu6jOs1BtkvRTWDDhw4zyEdp6q4eaMvqdSap1CG+7wM5jeLCi6z94wS0AuiuwA==",
             "dev": true,
             "requires": {
@@ -501,7 +501,7 @@
         },
         "@lerna/init": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/init/-/init-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/init/-/init-3.21.0.tgz",
             "integrity": "sha512-6CM0z+EFUkFfurwdJCR+LQQF6MqHbYDCBPyhu/d086LRf58GtYZYj49J8mKG9ktayp/TOIxL/pKKjgLD8QBPOg==",
             "dev": true,
             "requires": {
@@ -514,7 +514,7 @@
         },
         "@lerna/link": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/link/-/link-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/link/-/link-3.21.0.tgz",
             "integrity": "sha512-tGu9GxrX7Ivs+Wl3w1+jrLi1nQ36kNI32dcOssij6bg0oZ2M2MDEFI9UF2gmoypTaN9uO5TSsjCFS7aR79HbdQ==",
             "dev": true,
             "requires": {
@@ -527,7 +527,7 @@
         },
         "@lerna/list": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/list/-/list-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/list/-/list-3.21.0.tgz",
             "integrity": "sha512-KehRjE83B1VaAbRRkRy6jLX1Cin8ltsrQ7FHf2bhwhRHK0S54YuA6LOoBnY/NtA8bHDX/Z+G5sMY78X30NS9tg==",
             "dev": true,
             "requires": {
@@ -539,7 +539,7 @@
         },
         "@lerna/listable": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/listable/-/listable-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/listable/-/listable-3.18.5.tgz",
             "integrity": "sha512-Sdr3pVyaEv5A7ZkGGYR7zN+tTl2iDcinryBPvtuv20VJrXBE8wYcOks1edBTcOWsPjCE/rMP4bo1pseyk3UTsg==",
             "dev": true,
             "requires": {
@@ -550,7 +550,7 @@
         },
         "@lerna/log-packed": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/log-packed/-/log-packed-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/log-packed/-/log-packed-3.16.0.tgz",
             "integrity": "sha512-Fp+McSNBV/P2mnLUYTaSlG8GSmpXM7krKWcllqElGxvAqv6chk2K3c2k80MeVB4WvJ9tRjUUf+i7HUTiQ9/ckQ==",
             "dev": true,
             "requires": {
@@ -562,7 +562,7 @@
         },
         "@lerna/npm-conf": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/npm-conf/-/npm-conf-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/npm-conf/-/npm-conf-3.16.0.tgz",
             "integrity": "sha512-HbO3DUrTkCAn2iQ9+FF/eisDpWY5POQAOF1m7q//CZjdC2HSW3UYbKEGsSisFxSfaF9Z4jtrV+F/wX6qWs3CuA==",
             "dev": true,
             "requires": {
@@ -572,7 +572,7 @@
         },
         "@lerna/npm-dist-tag": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/npm-dist-tag/-/npm-dist-tag-3.18.5.tgz",
             "integrity": "sha512-xw0HDoIG6HreVsJND9/dGls1c+lf6vhu7yJoo56Sz5bvncTloYGLUppIfDHQr4ZvmPCK8rsh0euCVh2giPxzKQ==",
             "dev": true,
             "requires": {
@@ -585,7 +585,7 @@
         },
         "@lerna/npm-install": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/npm-install/-/npm-install-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/npm-install/-/npm-install-3.16.5.tgz",
             "integrity": "sha512-hfiKk8Eku6rB9uApqsalHHTHY+mOrrHeWEs+gtg7+meQZMTS3kzv4oVp5cBZigndQr3knTLjwthT/FX4KvseFg==",
             "dev": true,
             "requires": {
@@ -600,7 +600,7 @@
         },
         "@lerna/npm-publish": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/npm-publish/-/npm-publish-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/npm-publish/-/npm-publish-3.18.5.tgz",
             "integrity": "sha512-3etLT9+2L8JAx5F8uf7qp6iAtOLSMj+ZYWY6oUgozPi/uLqU0/gsMsEXh3F0+YVW33q0M61RpduBoAlOOZnaTg==",
             "dev": true,
             "requires": {
@@ -617,7 +617,7 @@
         },
         "@lerna/npm-run-script": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/npm-run-script/-/npm-run-script-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/npm-run-script/-/npm-run-script-3.16.5.tgz",
             "integrity": "sha512-1asRi+LjmVn3pMjEdpqKJZFT/3ZNpb+VVeJMwrJaV/3DivdNg7XlPK9LTrORuKU4PSvhdEZvJmSlxCKyDpiXsQ==",
             "dev": true,
             "requires": {
@@ -628,7 +628,7 @@
         },
         "@lerna/otplease": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/otplease/-/otplease-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/otplease/-/otplease-3.18.5.tgz",
             "integrity": "sha512-S+SldXAbcXTEDhzdxYLU0ZBKuYyURP/ND2/dK6IpKgLxQYh/z4ScljPDMyKymmEvgiEJmBsPZAAPfmNPEzxjog==",
             "dev": true,
             "requires": {
@@ -647,7 +647,7 @@
         },
         "@lerna/pack-directory": {
             "version": "3.16.4",
-            "resolved": "https://registry.npmjs.org/@lerna/pack-directory/-/pack-directory-3.16.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/pack-directory/-/pack-directory-3.16.4.tgz",
             "integrity": "sha512-uxSF0HZeGyKaaVHz5FroDY9A5NDDiCibrbYR6+khmrhZtY0Bgn6hWq8Gswl9iIlymA+VzCbshWIMX4o2O8C8ng==",
             "dev": true,
             "requires": {
@@ -663,7 +663,7 @@
         },
         "@lerna/package": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/package/-/package-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/package/-/package-3.16.0.tgz",
             "integrity": "sha512-2lHBWpaxcBoiNVbtyLtPUuTYEaB/Z+eEqRS9duxpZs6D+mTTZMNy6/5vpEVSCBmzvdYpyqhqaYjjSLvjjr5Riw==",
             "dev": true,
             "requires": {
@@ -674,7 +674,7 @@
         },
         "@lerna/package-graph": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/package-graph/-/package-graph-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/package-graph/-/package-graph-3.18.5.tgz",
             "integrity": "sha512-8QDrR9T+dBegjeLr+n9WZTVxUYUhIUjUgZ0gvNxUBN8S1WB9r6H5Yk56/MVaB64tA3oGAN9IIxX6w0WvTfFudA==",
             "dev": true,
             "requires": {
@@ -687,7 +687,7 @@
         },
         "@lerna/prerelease-id-from-version": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/prerelease-id-from-version/-/prerelease-id-from-version-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/prerelease-id-from-version/-/prerelease-id-from-version-3.16.0.tgz",
             "integrity": "sha512-qZyeUyrE59uOK8rKdGn7jQz+9uOpAaF/3hbslJVFL1NqF9ELDTqjCPXivuejMX/lN4OgD6BugTO4cR7UTq/sZA==",
             "dev": true,
             "requires": {
@@ -696,7 +696,7 @@
         },
         "@lerna/profiler": {
             "version": "3.20.0",
-            "resolved": "https://registry.npmjs.org/@lerna/profiler/-/profiler-3.20.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/profiler/-/profiler-3.20.0.tgz",
             "integrity": "sha512-bh8hKxAlm6yu8WEOvbLENm42i2v9SsR4WbrCWSbsmOElx3foRnMlYk7NkGECa+U5c3K4C6GeBbwgqs54PP7Ljg==",
             "dev": true,
             "requires": {
@@ -708,7 +708,7 @@
         },
         "@lerna/project": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/project/-/project-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/project/-/project-3.21.0.tgz",
             "integrity": "sha512-xT1mrpET2BF11CY32uypV2GPtPVm6Hgtha7D81GQP9iAitk9EccrdNjYGt5UBYASl4CIDXBRxwmTTVGfrCx82A==",
             "dev": true,
             "requires": {
@@ -728,7 +728,7 @@
         },
         "@lerna/prompt": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/prompt/-/prompt-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/prompt/-/prompt-3.18.5.tgz",
             "integrity": "sha512-rkKj4nm1twSbBEb69+Em/2jAERK8htUuV8/xSjN0NPC+6UjzAwY52/x9n5cfmpa9lyKf/uItp7chCI7eDmNTKQ==",
             "dev": true,
             "requires": {
@@ -738,7 +738,7 @@
         },
         "@lerna/publish": {
             "version": "3.22.1",
-            "resolved": "https://registry.npmjs.org/@lerna/publish/-/publish-3.22.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/publish/-/publish-3.22.1.tgz",
             "integrity": "sha512-PG9CM9HUYDreb1FbJwFg90TCBQooGjj+n/pb3gw/eH5mEDq0p8wKdLFe0qkiqUkm/Ub5C8DbVFertIo0Vd0zcw==",
             "dev": true,
             "requires": {
@@ -785,7 +785,7 @@
         },
         "@lerna/query-graph": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/query-graph/-/query-graph-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/query-graph/-/query-graph-3.18.5.tgz",
             "integrity": "sha512-50Lf4uuMpMWvJ306be3oQDHrWV42nai9gbIVByPBYJuVW8dT8O8pA3EzitNYBUdLL9/qEVbrR0ry1HD7EXwtRA==",
             "dev": true,
             "requires": {
@@ -795,7 +795,7 @@
         },
         "@lerna/resolve-symlink": {
             "version": "3.16.0",
-            "resolved": "https://registry.npmjs.org/@lerna/resolve-symlink/-/resolve-symlink-3.16.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/resolve-symlink/-/resolve-symlink-3.16.0.tgz",
             "integrity": "sha512-Ibj5e7njVHNJ/NOqT4HlEgPFPtPLWsO7iu59AM5bJDcAJcR96mLZ7KGVIsS2tvaO7akMEJvt2P+ErwCdloG3jQ==",
             "dev": true,
             "requires": {
@@ -806,7 +806,7 @@
         },
         "@lerna/rimraf-dir": {
             "version": "3.16.5",
-            "resolved": "https://registry.npmjs.org/@lerna/rimraf-dir/-/rimraf-dir-3.16.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/rimraf-dir/-/rimraf-dir-3.16.5.tgz",
             "integrity": "sha512-bQlKmO0pXUsXoF8lOLknhyQjOZsCc0bosQDoX4lujBXSWxHVTg1VxURtWf2lUjz/ACsJVDfvHZbDm8kyBk5okA==",
             "dev": true,
             "requires": {
@@ -818,7 +818,7 @@
         },
         "@lerna/run": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/@lerna/run/-/run-3.21.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/run/-/run-3.21.0.tgz",
             "integrity": "sha512-fJF68rT3veh+hkToFsBmUJ9MHc9yGXA7LSDvhziAojzOb0AI/jBDp6cEcDQyJ7dbnplba2Lj02IH61QUf9oW0Q==",
             "dev": true,
             "requires": {
@@ -835,7 +835,7 @@
         },
         "@lerna/run-lifecycle": {
             "version": "3.16.2",
-            "resolved": "https://registry.npmjs.org/@lerna/run-lifecycle/-/run-lifecycle-3.16.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/run-lifecycle/-/run-lifecycle-3.16.2.tgz",
             "integrity": "sha512-RqFoznE8rDpyyF0rOJy3+KjZCeTkO8y/OB9orPauR7G2xQ7PTdCpgo7EO6ZNdz3Al+k1BydClZz/j78gNCmL2A==",
             "dev": true,
             "requires": {
@@ -847,7 +847,7 @@
         },
         "@lerna/run-topologically": {
             "version": "3.18.5",
-            "resolved": "https://registry.npmjs.org/@lerna/run-topologically/-/run-topologically-3.18.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/run-topologically/-/run-topologically-3.18.5.tgz",
             "integrity": "sha512-6N1I+6wf4hLOnPW+XDZqwufyIQ6gqoPfHZFkfWlvTQ+Ue7CuF8qIVQ1Eddw5HKQMkxqN10thKOFfq/9NQZ4NUg==",
             "dev": true,
             "requires": {
@@ -858,7 +858,7 @@
         },
         "@lerna/symlink-binary": {
             "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@lerna/symlink-binary/-/symlink-binary-3.17.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/symlink-binary/-/symlink-binary-3.17.0.tgz",
             "integrity": "sha512-RLpy9UY6+3nT5J+5jkM5MZyMmjNHxZIZvXLV+Q3MXrf7Eaa1hNqyynyj4RO95fxbS+EZc4XVSk25DGFQbcRNSQ==",
             "dev": true,
             "requires": {
@@ -870,7 +870,7 @@
         },
         "@lerna/symlink-dependencies": {
             "version": "3.17.0",
-            "resolved": "https://registry.npmjs.org/@lerna/symlink-dependencies/-/symlink-dependencies-3.17.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/symlink-dependencies/-/symlink-dependencies-3.17.0.tgz",
             "integrity": "sha512-KmjU5YT1bpt6coOmdFueTJ7DFJL4H1w5eF8yAQ2zsGNTtZ+i5SGFBWpb9AQaw168dydc3s4eu0W0Sirda+F59Q==",
             "dev": true,
             "requires": {
@@ -900,7 +900,7 @@
         },
         "@lerna/version": {
             "version": "3.22.1",
-            "resolved": "https://registry.npmjs.org/@lerna/version/-/version-3.22.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@lerna/version/-/version-3.22.1.tgz",
             "integrity": "sha512-PSGt/K1hVqreAFoi3zjD0VEDupQ2WZVlVIwesrE5GbrL2BjXowjCsTDPqblahDUPy0hp6h7E2kG855yLTp62+g==",
             "dev": true,
             "requires": {
@@ -960,7 +960,7 @@
         },
         "@octokit/auth-token": {
             "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/auth-token/-/auth-token-2.4.2.tgz",
             "integrity": "sha512-jE/lE/IKIz2v1+/P0u4fJqv0kYwXOTujKemJMFr6FeopsxlIK3+wKDCJGnysg81XID5TgZQbIfuJ5J0lnTiuyQ==",
             "dev": true,
             "requires": {
@@ -969,7 +969,7 @@
         },
         "@octokit/endpoint": {
             "version": "6.0.5",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/endpoint/-/endpoint-6.0.5.tgz",
             "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
             "dev": true,
             "requires": {
@@ -980,13 +980,13 @@
             "dependencies": {
                 "is-plain-object": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-plain-object/-/is-plain-object-4.1.1.tgz",
                     "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
                     "dev": true
                 },
                 "universal-user-agent": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
                     "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
                     "dev": true
                 }
@@ -994,13 +994,13 @@
         },
         "@octokit/plugin-enterprise-rest": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/plugin-enterprise-rest/-/plugin-enterprise-rest-6.0.1.tgz",
             "integrity": "sha512-93uGjlhUD+iNg1iWhUENAtJata6w5nE+V4urXOAlIXdco6xNZtUSfYY8dzp3Udy74aqO/B5UZL80x/YMa5PKRw==",
             "dev": true
         },
         "@octokit/plugin-paginate-rest": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-1.1.2.tgz",
             "integrity": "sha512-jbsSoi5Q1pj63sC16XIUboklNw+8tL9VOnJsWycWYR78TKss5PVpIPb1TUUcMQ+bBh7cY579cVAWmf5qG+dw+Q==",
             "dev": true,
             "requires": {
@@ -1009,7 +1009,7 @@
             "dependencies": {
                 "@octokit/types": {
                     "version": "2.16.2",
-                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/types/-/types-2.16.2.tgz",
                     "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
                     "dev": true,
                     "requires": {
@@ -1020,13 +1020,13 @@
         },
         "@octokit/plugin-request-log": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/plugin-request-log/-/plugin-request-log-1.0.0.tgz",
             "integrity": "sha512-ywoxP68aOT3zHCLgWZgwUJatiENeHE7xJzYjfz8WI0goynp96wETBF+d95b8g/uL4QmS6owPVlaxiz3wyMAzcw==",
             "dev": true
         },
         "@octokit/plugin-rest-endpoint-methods": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-2.4.0.tgz",
             "integrity": "sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==",
             "dev": true,
             "requires": {
@@ -1036,7 +1036,7 @@
             "dependencies": {
                 "@octokit/types": {
                     "version": "2.16.2",
-                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/types/-/types-2.16.2.tgz",
                     "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
                     "dev": true,
                     "requires": {
@@ -1047,7 +1047,7 @@
         },
         "@octokit/request": {
             "version": "5.4.7",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/request/-/request-5.4.7.tgz",
             "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
             "dev": true,
             "requires": {
@@ -1063,7 +1063,7 @@
             "dependencies": {
                 "@octokit/request-error": {
                     "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/request-error/-/request-error-2.0.2.tgz",
                     "integrity": "sha512-2BrmnvVSV1MXQvEkrb9zwzP0wXFNbPJij922kYBTLIlIafukrGOb+ABBT2+c6wZiuyWDH1K1zmjGQ0toN/wMWw==",
                     "dev": true,
                     "requires": {
@@ -1074,13 +1074,13 @@
                 },
                 "is-plain-object": {
                     "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-plain-object/-/is-plain-object-4.1.1.tgz",
                     "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
                     "dev": true
                 },
                 "universal-user-agent": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
                     "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
                     "dev": true
                 }
@@ -1088,7 +1088,7 @@
         },
         "@octokit/request-error": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-1.2.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/request-error/-/request-error-1.2.1.tgz",
             "integrity": "sha512-+6yDyk1EES6WK+l3viRDElw96MvwfJxCt45GvmjDUKWjYIb3PJZQkq3i46TwGwoPD4h8NmTrENmtyA1FwbmhRA==",
             "dev": true,
             "requires": {
@@ -1099,7 +1099,7 @@
             "dependencies": {
                 "@octokit/types": {
                     "version": "2.16.2",
-                    "resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.16.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/types/-/types-2.16.2.tgz",
                     "integrity": "sha512-O75k56TYvJ8WpAakWwYRN8Bgu60KrmX0z1KqFp1kNiFNkgW+JW+9EBKZ+S33PU6SLvbihqd+3drvPxKK68Ee8Q==",
                     "dev": true,
                     "requires": {
@@ -1110,7 +1110,7 @@
         },
         "@octokit/rest": {
             "version": "16.43.2",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.43.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/rest/-/rest-16.43.2.tgz",
             "integrity": "sha512-ngDBevLbBTFfrHZeiS7SAMAZ6ssuVmXuya+F/7RaVvlysgGa1JKJkKWY+jV6TCJYcW0OALfJ7nTIGXcBXzycfQ==",
             "dev": true,
             "requires": {
@@ -1134,7 +1134,7 @@
         },
         "@octokit/types": {
             "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@octokit/types/-/types-5.4.0.tgz",
             "integrity": "sha512-D/uotqF69M50OIlwMqgyIg9PuLT2daOiBAYF0P40I2ekFA2ESwwBY5dxZe/UhXdPvIbNKDzuZmQrO7rMpuFbcg==",
             "dev": true,
             "requires": {
@@ -1143,7 +1143,7 @@
         },
         "@types/glob": {
             "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@types/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
             "dev": true,
             "requires": {
@@ -1153,31 +1153,31 @@
         },
         "@types/minimatch": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
             "dev": true
         },
         "@types/minimist": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@types/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
             "dev": true
         },
         "@types/node": {
             "version": "14.0.27",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@types/node/-/node-14.0.27.tgz",
             "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==",
             "dev": true
         },
         "@types/normalize-package-data": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
             "dev": true
         },
         "@zkochan/cmd-shim": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz",
             "integrity": "sha512-o8l0+x7C7sMZU3v9GuJIAU10qQLtwR1dtRQIOmlNMtyaqhmpXOzx1HWiYoWfmmf9HHZoAkXpc9TM9PQYF9d4Jg==",
             "dev": true,
             "requires": {
@@ -1222,7 +1222,7 @@
         },
         "ajv": {
             "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ajv/-/ajv-6.12.3.tgz",
             "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
             "dev": true,
             "requires": {
@@ -1255,7 +1255,7 @@
         },
         "any-promise": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/any-promise/-/any-promise-1.3.0.tgz",
             "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
             "dev": true
         },
@@ -1304,7 +1304,7 @@
         },
         "array-differ": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/array-differ/-/array-differ-2.1.0.tgz",
             "integrity": "sha512-KbUpJgx909ZscOc/7CLATBFam7P1Z1QRQInvgT0UztM9Q72aGKCunKASAl7WNW0tnPmPyEMeMhdsfWhfmW037w==",
             "dev": true
         },
@@ -1476,13 +1476,13 @@
         },
         "before-after-hook": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/before-after-hook/-/before-after-hook-2.1.0.tgz",
             "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A==",
             "dev": true
         },
         "bluebird": {
             "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "dev": true
         },
@@ -1551,13 +1551,13 @@
         },
         "byte-size": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/byte-size/-/byte-size-5.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/byte-size/-/byte-size-5.0.1.tgz",
             "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw==",
             "dev": true
         },
         "cacache": {
             "version": "12.0.4",
-            "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/cacache/-/cacache-12.0.4.tgz",
             "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
             "dev": true,
             "requires": {
@@ -1627,13 +1627,13 @@
         },
         "camelcase": {
             "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase/-/camelcase-5.3.1.tgz",
             "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
             "dev": true
         },
         "camelcase-keys": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
             "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
             "dev": true,
             "requires": {
@@ -1667,13 +1667,13 @@
         },
         "chownr": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
             "dev": true
         },
         "ci-info": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true
         },
@@ -1711,13 +1711,13 @@
         },
         "cli-width": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/cli-width/-/cli-width-2.2.1.tgz",
             "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
             "dev": true
         },
         "cliui": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/cliui/-/cliui-5.0.0.tgz",
             "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
             "dev": true,
             "requires": {
@@ -1728,7 +1728,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
@@ -1740,7 +1740,7 @@
                 },
                 "string-width": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/string-width/-/string-width-3.1.0.tgz",
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
@@ -1751,7 +1751,7 @@
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
@@ -1768,7 +1768,7 @@
         },
         "clone-deep": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/clone-deep/-/clone-deep-4.0.1.tgz",
             "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
             "requires": {
@@ -1829,7 +1829,7 @@
         },
         "compare-func": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/compare-func/-/compare-func-2.0.0.tgz",
             "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
             "dev": true,
             "requires": {
@@ -1839,7 +1839,7 @@
             "dependencies": {
                 "dot-prop": {
                     "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/dot-prop/-/dot-prop-5.2.0.tgz",
                     "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
                     "dev": true,
                     "requires": {
@@ -1848,7 +1848,7 @@
                 },
                 "is-obj": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-obj/-/is-obj-2.0.0.tgz",
                     "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
                     "dev": true
                 }
@@ -1896,7 +1896,7 @@
         },
         "conventional-changelog-angular": {
             "version": "5.0.11",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
             "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
             "dev": true,
             "requires": {
@@ -1906,7 +1906,7 @@
         },
         "conventional-changelog-core": {
             "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-changelog-core/-/conventional-changelog-core-3.2.3.tgz",
             "integrity": "sha512-LMMX1JlxPIq/Ez5aYAYS5CpuwbOk6QFp8O4HLAcZxe3vxoCtABkhfjetk8IYdRB9CDQGwJFLR3Dr55Za6XKgUQ==",
             "dev": true,
             "requires": {
@@ -1927,7 +1927,7 @@
             "dependencies": {
                 "through2": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/through2/-/through2-3.0.2.tgz",
                     "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
                     "dev": true,
                     "requires": {
@@ -1939,13 +1939,13 @@
         },
         "conventional-changelog-preset-loader": {
             "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.3.4.tgz",
             "integrity": "sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==",
             "dev": true
         },
         "conventional-changelog-writer": {
             "version": "4.0.17",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
             "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
             "dev": true,
             "requires": {
@@ -1963,7 +1963,7 @@
             "dependencies": {
                 "through2": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/through2/-/through2-3.0.2.tgz",
                     "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
                     "dev": true,
                     "requires": {
@@ -1975,7 +1975,7 @@
         },
         "conventional-commits-filter": {
             "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-commits-filter/-/conventional-commits-filter-2.0.6.tgz",
             "integrity": "sha512-4g+sw8+KA50/Qwzfr0hL5k5NWxqtrOVw4DDk3/h6L85a9Gz0/Eqp3oP+CWCNfesBvZZZEFHF7OTEbRe+yYSyKw==",
             "dev": true,
             "requires": {
@@ -1985,7 +1985,7 @@
         },
         "conventional-commits-parser": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-commits-parser/-/conventional-commits-parser-3.1.0.tgz",
             "integrity": "sha512-RSo5S0WIwXZiRxUGTPuYFbqvrR4vpJ1BDdTlthFgvHt5kEdnd1+pdvwWphWn57/oIl4V72NMmOocFqqJ8mFFhA==",
             "dev": true,
             "requires": {
@@ -2000,7 +2000,7 @@
             "dependencies": {
                 "through2": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/through2/-/through2-3.0.2.tgz",
                     "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
                     "dev": true,
                     "requires": {
@@ -2012,7 +2012,7 @@
         },
         "conventional-recommended-bump": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/conventional-recommended-bump/-/conventional-recommended-bump-5.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/conventional-recommended-bump/-/conventional-recommended-bump-5.0.1.tgz",
             "integrity": "sha512-RVdt0elRcCxL90IrNP0fYCpq1uGt2MALko0eyeQ+zQuDVWtMGAy9ng6yYn3kax42lCj9+XBxQ8ZN6S9bdKxDhQ==",
             "dev": true,
             "requires": {
@@ -2028,13 +2028,13 @@
             "dependencies": {
                 "camelcase": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "dev": true
                 },
                 "camelcase-keys": {
                     "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                     "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
                     "dev": true,
                     "requires": {
@@ -2057,19 +2057,19 @@
                 },
                 "indent-string": {
                     "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/indent-string/-/indent-string-3.2.0.tgz",
                     "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
                     "dev": true
                 },
                 "map-obj": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/map-obj/-/map-obj-2.0.0.tgz",
                     "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
                     "dev": true
                 },
                 "meow": {
                     "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/meow/-/meow-4.0.1.tgz",
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
@@ -2086,7 +2086,7 @@
                 },
                 "minimist-options": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minimist-options/-/minimist-options-3.0.2.tgz",
                     "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
                     "dev": true,
                     "requires": {
@@ -2096,13 +2096,13 @@
                 },
                 "quick-lru": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/quick-lru/-/quick-lru-1.1.0.tgz",
                     "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
                     "dev": true
                 },
                 "readable-stream": {
                     "version": "3.6.0",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
                     "dev": true,
                     "requires": {
@@ -2113,7 +2113,7 @@
                 },
                 "redent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/redent/-/redent-2.0.0.tgz",
                     "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
                     "dev": true,
                     "requires": {
@@ -2123,13 +2123,13 @@
                 },
                 "strip-indent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-indent/-/strip-indent-2.0.0.tgz",
                     "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
                     "dev": true
                 },
                 "trim-newlines": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/trim-newlines/-/trim-newlines-2.0.0.tgz",
                     "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
                     "dev": true
                 }
@@ -2188,7 +2188,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -2205,7 +2205,7 @@
         },
         "cyclist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/cyclist/-/cyclist-1.0.1.tgz",
             "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=",
             "dev": true
         },
@@ -2387,7 +2387,7 @@
         },
         "dir-glob": {
             "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/dir-glob/-/dir-glob-2.2.2.tgz",
             "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
             "dev": true,
             "requires": {
@@ -2433,13 +2433,13 @@
         },
         "emoji-regex": {
             "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/emoji-regex/-/emoji-regex-7.0.3.tgz",
             "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
         "encoding": {
             "version": "0.1.13",
-            "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/encoding/-/encoding-0.1.13.tgz",
             "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
             "dev": true,
             "requires": {
@@ -2448,7 +2448,7 @@
         },
         "end-of-stream": {
             "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
             "dev": true,
             "requires": {
@@ -2457,13 +2457,13 @@
         },
         "env-paths": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/env-paths/-/env-paths-2.2.0.tgz",
             "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
             "dev": true
         },
         "envinfo": {
             "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/envinfo/-/envinfo-7.7.2.tgz",
             "integrity": "sha512-k3Eh5bKuQnZjm49/L7H4cHzs2FlL5QjbTB3JrPxoTI8aJG7hVMe4uKyJxSYH4ahseby2waUwk5OaKX/nAsaYgg==",
             "dev": true
         },
@@ -2484,7 +2484,7 @@
         },
         "es-abstract": {
             "version": "1.17.6",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/es-abstract/-/es-abstract-1.17.6.tgz",
             "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
             "dev": true,
             "requires": {
@@ -2503,7 +2503,7 @@
         },
         "es-to-primitive": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
             "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
             "dev": true,
             "requires": {
@@ -2639,7 +2639,7 @@
         },
         "external-editor": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/external-editor/-/external-editor-3.1.0.tgz",
             "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
             "dev": true,
             "requires": {
@@ -2650,7 +2650,7 @@
             "dependencies": {
                 "iconv-lite": {
                     "version": "0.4.24",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/iconv-lite/-/iconv-lite-0.4.24.tgz",
                     "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
                     "dev": true,
                     "requires": {
@@ -2732,7 +2732,7 @@
         },
         "fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
@@ -2752,7 +2752,7 @@
             "dependencies": {
                 "glob-parent": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
@@ -2762,7 +2762,7 @@
                     "dependencies": {
                         "is-glob": {
                             "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
@@ -2775,13 +2775,13 @@
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
         "figgy-pudding": {
             "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
             "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw==",
             "dev": true
         },
@@ -2819,7 +2819,7 @@
         },
         "find-up": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/find-up/-/find-up-3.0.0.tgz",
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "dev": true,
             "requires": {
@@ -2880,7 +2880,7 @@
         },
         "fs-extra": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
             "dev": true,
             "requires": {
@@ -2891,7 +2891,7 @@
         },
         "fs-minipass": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/fs-minipass/-/fs-minipass-1.2.7.tgz",
             "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
             "dev": true,
             "requires": {
@@ -2946,7 +2946,7 @@
         },
         "get-caller-file": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
             "dev": true
         },
@@ -3129,7 +3129,7 @@
         },
         "get-port": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/get-port/-/get-port-4.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/get-port/-/get-port-4.2.0.tgz",
             "integrity": "sha512-/b3jarXkH8KJoOMQc3uVGHASwGLPq3gSFJ7tgJm2diza+bydJPTGOibin2steecKeOylE8oY2JERlVWkAJO6yw==",
             "dev": true
         },
@@ -3178,13 +3178,13 @@
             "dependencies": {
                 "camelcase": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "dev": true
                 },
                 "camelcase-keys": {
                     "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                     "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
                     "dev": true,
                     "requires": {
@@ -3195,19 +3195,19 @@
                 },
                 "indent-string": {
                     "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/indent-string/-/indent-string-3.2.0.tgz",
                     "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
                     "dev": true
                 },
                 "map-obj": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/map-obj/-/map-obj-2.0.0.tgz",
                     "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
                     "dev": true
                 },
                 "meow": {
                     "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/meow/-/meow-4.0.1.tgz",
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
@@ -3224,7 +3224,7 @@
                 },
                 "minimist-options": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minimist-options/-/minimist-options-3.0.2.tgz",
                     "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
                     "dev": true,
                     "requires": {
@@ -3234,13 +3234,13 @@
                 },
                 "quick-lru": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/quick-lru/-/quick-lru-1.1.0.tgz",
                     "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
                     "dev": true
                 },
                 "redent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/redent/-/redent-2.0.0.tgz",
                     "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
                     "dev": true,
                     "requires": {
@@ -3250,13 +3250,13 @@
                 },
                 "strip-indent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-indent/-/strip-indent-2.0.0.tgz",
                     "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
                     "dev": true
                 },
                 "trim-newlines": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/trim-newlines/-/trim-newlines-2.0.0.tgz",
                     "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
                     "dev": true
                 }
@@ -3282,7 +3282,7 @@
         },
         "git-semver-tags": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/git-semver-tags/-/git-semver-tags-2.0.3.tgz",
             "integrity": "sha512-tj4FD4ww2RX2ae//jSrXZzrocla9db5h0V7ikPl1P/WwoZar9epdUhwR7XHXSgc+ZkNq72BEEerqQuicoEQfzA==",
             "dev": true,
             "requires": {
@@ -3292,13 +3292,13 @@
             "dependencies": {
                 "camelcase": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase/-/camelcase-4.1.0.tgz",
                     "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
                     "dev": true
                 },
                 "camelcase-keys": {
                     "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
                     "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
                     "dev": true,
                     "requires": {
@@ -3309,19 +3309,19 @@
                 },
                 "indent-string": {
                     "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/indent-string/-/indent-string-3.2.0.tgz",
                     "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
                     "dev": true
                 },
                 "map-obj": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/map-obj/-/map-obj-2.0.0.tgz",
                     "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
                     "dev": true
                 },
                 "meow": {
                     "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/meow/-/meow-4.0.1.tgz",
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
@@ -3338,7 +3338,7 @@
                 },
                 "minimist-options": {
                     "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minimist-options/-/minimist-options-3.0.2.tgz",
                     "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
                     "dev": true,
                     "requires": {
@@ -3348,13 +3348,13 @@
                 },
                 "quick-lru": {
                     "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/quick-lru/-/quick-lru-1.1.0.tgz",
                     "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
                     "dev": true
                 },
                 "redent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/redent/-/redent-2.0.0.tgz",
                     "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
                     "dev": true,
                     "requires": {
@@ -3364,13 +3364,13 @@
                 },
                 "strip-indent": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-indent/-/strip-indent-2.0.0.tgz",
                     "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
                     "dev": true
                 },
                 "trim-newlines": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/trim-newlines/-/trim-newlines-2.0.0.tgz",
                     "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
                     "dev": true
                 }
@@ -3378,7 +3378,7 @@
         },
         "git-up": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/git-up/-/git-up-4.0.2.tgz",
             "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
             "dev": true,
             "requires": {
@@ -3388,7 +3388,7 @@
         },
         "git-url-parse": {
             "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/git-url-parse/-/git-url-parse-11.1.3.tgz",
             "integrity": "sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==",
             "dev": true,
             "requires": {
@@ -3406,7 +3406,7 @@
         },
         "glob": {
             "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/glob/-/glob-7.1.6.tgz",
             "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
             "dev": true,
             "requires": {
@@ -3420,7 +3420,7 @@
         },
         "glob-parent": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/glob-parent/-/glob-parent-5.1.1.tgz",
             "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
             "dev": true,
             "requires": {
@@ -3435,7 +3435,7 @@
         },
         "globby": {
             "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/globby/-/globby-9.2.0.tgz",
             "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
             "dev": true,
             "requires": {
@@ -3451,13 +3451,13 @@
         },
         "graceful-fs": {
             "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/graceful-fs/-/graceful-fs-4.2.4.tgz",
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
             "dev": true
         },
         "handlebars": {
             "version": "4.7.6",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/handlebars/-/handlebars-4.7.6.tgz",
             "integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
             "dev": true,
             "requires": {
@@ -3484,7 +3484,7 @@
         },
         "har-validator": {
             "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/har-validator/-/har-validator-5.1.5.tgz",
             "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "dev": true,
             "requires": {
@@ -3494,7 +3494,7 @@
         },
         "hard-rejection": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/hard-rejection/-/hard-rejection-2.1.0.tgz",
             "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
             "dev": true
         },
@@ -3515,7 +3515,7 @@
         },
         "has-symbols": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/has-symbols/-/has-symbols-1.0.1.tgz",
             "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
             "dev": true
         },
@@ -3559,7 +3559,7 @@
         },
         "hosted-git-info": {
             "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
             "dev": true
         },
@@ -3611,7 +3611,7 @@
         },
         "iconv-lite": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/iconv-lite/-/iconv-lite-0.6.2.tgz",
             "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
             "dev": true,
             "requires": {
@@ -3626,13 +3626,13 @@
         },
         "ignore": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true
         },
         "ignore-walk": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ignore-walk/-/ignore-walk-3.0.3.tgz",
             "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
             "dev": true,
             "requires": {
@@ -3659,7 +3659,7 @@
         },
         "import-local": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/import-local/-/import-local-2.0.0.tgz",
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
             "dev": true,
             "requires": {
@@ -3675,13 +3675,13 @@
         },
         "indent-string": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/indent-string/-/indent-string-4.0.0.tgz",
             "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
             "dev": true
         },
         "infer-owner": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/infer-owner/-/infer-owner-1.0.4.tgz",
             "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
             "dev": true
         },
@@ -3725,7 +3725,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -3733,7 +3733,7 @@
         },
         "inquirer": {
             "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/inquirer/-/inquirer-6.5.2.tgz",
             "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
             "dev": true,
             "requires": {
@@ -3844,13 +3844,13 @@
         },
         "is-callable": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-callable/-/is-callable-1.2.0.tgz",
             "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
             "dev": true
         },
         "is-ci": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-ci/-/is-ci-2.0.0.tgz",
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
             "dev": true,
             "requires": {
@@ -3879,7 +3879,7 @@
         },
         "is-date-object": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
             "dev": true
         },
@@ -3922,7 +3922,7 @@
         },
         "is-finite": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-finite/-/is-finite-1.1.0.tgz",
             "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
             "dev": true
         },
@@ -3937,7 +3937,7 @@
         },
         "is-glob": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
             "dev": true,
             "requires": {
@@ -3987,7 +3987,7 @@
         },
         "is-regex": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-regex/-/is-regex-1.1.1.tgz",
             "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
             "dev": true,
             "requires": {
@@ -3996,7 +3996,7 @@
         },
         "is-ssh": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-ssh/-/is-ssh-1.3.2.tgz",
             "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
             "dev": true,
             "requires": {
@@ -4011,7 +4011,7 @@
         },
         "is-symbol": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-symbol/-/is-symbol-1.0.3.tgz",
             "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
             "dev": true,
             "requires": {
@@ -4020,7 +4020,7 @@
         },
         "is-text-path": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-text-path/-/is-text-path-1.0.1.tgz",
             "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
             "dev": true,
             "requires": {
@@ -4071,13 +4071,13 @@
         },
         "js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
             "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/js-yaml/-/js-yaml-3.14.0.tgz",
             "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
             "dev": true,
             "requires": {
@@ -4144,13 +4144,13 @@
         },
         "kind-of": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
         "lerna": {
             "version": "3.22.1",
-            "resolved": "https://registry.npmjs.org/lerna/-/lerna-3.22.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/lerna/-/lerna-3.22.1.tgz",
             "integrity": "sha512-vk1lfVRFm+UuEFA7wkLKeSF7Iz13W+N/vFd48aW2yuS7Kv0RbNm2/qcDPV863056LMfkRlsEe+QYOw3palj5Lg==",
             "dev": true,
             "requires": {
@@ -4176,13 +4176,13 @@
         },
         "lines-and-columns": {
             "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
             "dev": true
         },
         "load-json-file": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/load-json-file/-/load-json-file-5.3.0.tgz",
             "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
             "dev": true,
             "requires": {
@@ -4195,7 +4195,7 @@
         },
         "locate-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/locate-path/-/locate-path-3.0.0.tgz",
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "dev": true,
             "requires": {
@@ -4257,7 +4257,7 @@
         },
         "lodash.templatesettings": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
             "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
             "dev": true,
             "requires": {
@@ -4291,7 +4291,7 @@
         },
         "macos-release": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/macos-release/-/macos-release-2.4.1.tgz",
             "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
             "dev": true
         },
@@ -4306,7 +4306,7 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
@@ -4314,7 +4314,7 @@
         },
         "make-fetch-happen": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/make-fetch-happen/-/make-fetch-happen-5.0.2.tgz",
             "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
             "dev": true,
             "requires": {
@@ -4339,7 +4339,7 @@
         },
         "map-obj": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/map-obj/-/map-obj-4.1.0.tgz",
             "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
             "dev": true
         },
@@ -4354,7 +4354,7 @@
         },
         "meow": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/meow/-/meow-7.1.0.tgz",
             "integrity": "sha512-kq5F0KVteskZ3JdfyQFivJEj2RaA8NFsS4+r9DaMKLcUHpk5OcHS3Q0XkCXONB1mZRPsu/Y/qImKri0nwSEZog==",
             "dev": true,
             "requires": {
@@ -4373,7 +4373,7 @@
             "dependencies": {
                 "find-up": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/find-up/-/find-up-4.1.0.tgz",
                     "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
                     "dev": true,
                     "requires": {
@@ -4383,7 +4383,7 @@
                 },
                 "locate-path": {
                     "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/locate-path/-/locate-path-5.0.0.tgz",
                     "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
                     "dev": true,
                     "requires": {
@@ -4392,7 +4392,7 @@
                 },
                 "p-locate": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-locate/-/p-locate-4.1.0.tgz",
                     "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
                     "dev": true,
                     "requires": {
@@ -4401,7 +4401,7 @@
                 },
                 "parse-json": {
                     "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/parse-json/-/parse-json-5.0.1.tgz",
                     "integrity": "sha512-ztoZ4/DYeXQq4E21v169sC8qWINGpcosGv9XhTDvg9/hWvx/zrFkc9BiWxR58OJLHGk28j5BL0SDLeV2WmFZlQ==",
                     "dev": true,
                     "requires": {
@@ -4413,13 +4413,13 @@
                 },
                 "path-exists": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/path-exists/-/path-exists-4.0.0.tgz",
                     "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
                 },
                 "read-pkg": {
                     "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/read-pkg/-/read-pkg-5.2.0.tgz",
                     "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
                     "dev": true,
                     "requires": {
@@ -4431,7 +4431,7 @@
                     "dependencies": {
                         "type-fest": {
                             "version": "0.6.0",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/type-fest/-/type-fest-0.6.0.tgz",
                             "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
                             "dev": true
                         }
@@ -4439,7 +4439,7 @@
                 },
                 "read-pkg-up": {
                     "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
                     "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
                     "dev": true,
                     "requires": {
@@ -4450,7 +4450,7 @@
                     "dependencies": {
                         "type-fest": {
                             "version": "0.8.1",
-                            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+                            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/type-fest/-/type-fest-0.8.1.tgz",
                             "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
                             "dev": true
                         }
@@ -4458,13 +4458,13 @@
                 },
                 "type-fest": {
                     "version": "0.13.1",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/type-fest/-/type-fest-0.13.1.tgz",
                     "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
                     "dev": true
                 },
                 "yargs-parser": {
                     "version": "18.1.3",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/yargs-parser/-/yargs-parser-18.1.3.tgz",
                     "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
                     "dev": true,
                     "requires": {
@@ -4476,7 +4476,7 @@
         },
         "merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true
         },
@@ -4503,13 +4503,13 @@
         },
         "mime-db": {
             "version": "1.44.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/mime-db/-/mime-db-1.44.0.tgz",
             "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
             "dev": true
         },
         "mime-types": {
             "version": "2.1.27",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/mime-types/-/mime-types-2.1.27.tgz",
             "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
             "dev": true,
             "requires": {
@@ -4524,7 +4524,7 @@
         },
         "min-indent": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/min-indent/-/min-indent-1.0.1.tgz",
             "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
             "dev": true
         },
@@ -4539,13 +4539,13 @@
         },
         "minimist": {
             "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minimist/-/minimist-1.2.5.tgz",
             "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "minimist-options": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minimist-options/-/minimist-options-4.1.0.tgz",
             "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
             "dev": true,
             "requires": {
@@ -4556,7 +4556,7 @@
         },
         "minipass": {
             "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minipass/-/minipass-2.9.0.tgz",
             "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
             "dev": true,
             "requires": {
@@ -4566,7 +4566,7 @@
         },
         "minizlib": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/minizlib/-/minizlib-1.3.3.tgz",
             "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
             "dev": true,
             "requires": {
@@ -4614,7 +4614,7 @@
         },
         "mkdirp": {
             "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/mkdirp/-/mkdirp-0.5.5.tgz",
             "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "dev": true,
             "requires": {
@@ -4623,7 +4623,7 @@
         },
         "mkdirp-promise": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
             "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
             "dev": true,
             "requires": {
@@ -4658,7 +4658,7 @@
         },
         "multimatch": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/multimatch/-/multimatch-3.0.0.tgz",
             "integrity": "sha512-22foS/gqQfANZ3o+W7ST2x25ueHDVNWl/b9OlGcLpy/iKxjCpvcNCM51YCenUi7Mt/jAjjqv8JwZRs8YP5sRjA==",
             "dev": true,
             "requires": {
@@ -4676,7 +4676,7 @@
         },
         "mz": {
             "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/mz/-/mz-2.7.0.tgz",
             "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
             "dev": true,
             "requires": {
@@ -4706,7 +4706,7 @@
         },
         "neo-async": {
             "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
@@ -4724,7 +4724,7 @@
         },
         "node-fetch-npm": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
             "integrity": "sha512-iOuIQDWDyjhv9qSDrj9aq/klt6F9z1p2otB3AV7v3zBDcL/x+OfGsvGQZZCcMZbUf4Ujw1xGNQkjvGnVT22cKg==",
             "dev": true,
             "requires": {
@@ -4735,7 +4735,7 @@
         },
         "node-gyp": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/node-gyp/-/node-gyp-5.1.1.tgz",
             "integrity": "sha512-WH0WKGi+a4i4DUt2mHnvocex/xPLp9pYt5R6M2JdFB7pJ7Z34hveZ4nDTGTiLXCkitA9T8HFZjhinBCiVHYcWw==",
             "dev": true,
             "requires": {
@@ -4754,7 +4754,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -4762,7 +4762,7 @@
         },
         "nopt": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/nopt/-/nopt-4.0.3.tgz",
             "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
             "dev": true,
             "requires": {
@@ -4784,7 +4784,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -4798,7 +4798,7 @@
         },
         "npm-bundled": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-bundled/-/npm-bundled-1.1.1.tgz",
             "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
             "dev": true,
             "requires": {
@@ -4807,7 +4807,7 @@
         },
         "npm-lifecycle": {
             "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
             "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
             "dev": true,
             "requires": {
@@ -4823,13 +4823,13 @@
         },
         "npm-normalize-package-bin": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
             "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
             "dev": true
         },
         "npm-package-arg": {
             "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-package-arg/-/npm-package-arg-6.1.1.tgz",
             "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
             "dev": true,
             "requires": {
@@ -4841,7 +4841,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -4849,7 +4849,7 @@
         },
         "npm-packlist": {
             "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-packlist/-/npm-packlist-1.4.8.tgz",
             "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
             "dev": true,
             "requires": {
@@ -4860,7 +4860,7 @@
         },
         "npm-pick-manifest": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/npm-pick-manifest/-/npm-pick-manifest-3.0.2.tgz",
             "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
             "dev": true,
             "requires": {
@@ -4871,7 +4871,7 @@
             "dependencies": {
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -4949,7 +4949,7 @@
         },
         "object-inspect": {
             "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/object-inspect/-/object-inspect-1.8.0.tgz",
             "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
             "dev": true
         },
@@ -4970,7 +4970,7 @@
         },
         "object.assign": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/object.assign/-/object.assign-4.1.0.tgz",
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
@@ -4982,7 +4982,7 @@
         },
         "object.getownpropertydescriptors": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
             "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
             "dev": true,
             "requires": {
@@ -5063,7 +5063,7 @@
         },
         "p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "requires": {
@@ -5072,7 +5072,7 @@
         },
         "p-locate": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-locate/-/p-locate-3.0.0.tgz",
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
@@ -5081,7 +5081,7 @@
         },
         "p-map": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-map/-/p-map-2.1.0.tgz",
             "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
             "dev": true
         },
@@ -5117,7 +5117,7 @@
         },
         "p-try": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true
         },
@@ -5132,7 +5132,7 @@
         },
         "parallel-transform": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/parallel-transform/-/parallel-transform-1.2.0.tgz",
             "integrity": "sha512-P2vSmIu38uIlvdcU7fDkyrxj33gTUy/ABO5ZUbGowxNCopBq/OoD42bP4UmMrJoPyk4Uqf0mu3mtWBhHCZD8yg==",
             "dev": true,
             "requires": {
@@ -5159,7 +5159,7 @@
         },
         "parse-path": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/parse-path/-/parse-path-4.0.2.tgz",
             "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
             "dev": true,
             "requires": {
@@ -5169,7 +5169,7 @@
         },
         "parse-url": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/parse-url/-/parse-url-5.0.2.tgz",
             "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
             "dev": true,
             "requires": {
@@ -5226,7 +5226,7 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
@@ -5240,7 +5240,7 @@
         },
         "pify": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-4.0.1.tgz",
             "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
             "dev": true
         },
@@ -5261,7 +5261,7 @@
         },
         "pkg-dir": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pkg-dir/-/pkg-dir-3.0.0.tgz",
             "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
             "dev": true,
             "requires": {
@@ -5313,7 +5313,7 @@
         },
         "protocols": {
             "version": "1.4.8",
-            "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/protocols/-/protocols-1.4.8.tgz",
             "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
             "dev": true
         },
@@ -5328,7 +5328,7 @@
         },
         "psl": {
             "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/psl/-/psl-1.8.0.tgz",
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
             "dev": true
         },
@@ -5385,7 +5385,7 @@
         },
         "quick-lru": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/quick-lru/-/quick-lru-4.0.1.tgz",
             "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
             "dev": true
         },
@@ -5400,7 +5400,7 @@
         },
         "read-cmd-shim": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/read-cmd-shim/-/read-cmd-shim-1.0.5.tgz",
             "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
             "dev": true,
             "requires": {
@@ -5409,7 +5409,7 @@
         },
         "read-package-json": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/read-package-json/-/read-package-json-2.1.1.tgz",
             "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
             "dev": true,
             "requires": {
@@ -5444,7 +5444,7 @@
             "dependencies": {
                 "load-json-file": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/load-json-file/-/load-json-file-4.0.0.tgz",
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
@@ -5456,7 +5456,7 @@
                 },
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
@@ -5474,7 +5474,7 @@
             "dependencies": {
                 "find-up": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/find-up/-/find-up-2.1.0.tgz",
                     "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
                     "dev": true,
                     "requires": {
@@ -5483,7 +5483,7 @@
                 },
                 "locate-path": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/locate-path/-/locate-path-2.0.0.tgz",
                     "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
                     "dev": true,
                     "requires": {
@@ -5493,7 +5493,7 @@
                 },
                 "p-limit": {
                     "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-limit/-/p-limit-1.3.0.tgz",
                     "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
                     "dev": true,
                     "requires": {
@@ -5502,7 +5502,7 @@
                 },
                 "p-locate": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-locate/-/p-locate-2.0.0.tgz",
                     "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
                     "dev": true,
                     "requires": {
@@ -5511,7 +5511,7 @@
                 },
                 "p-try": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/p-try/-/p-try-1.0.0.tgz",
                     "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
                     "dev": true
                 }
@@ -5519,7 +5519,7 @@
         },
         "readable-stream": {
             "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/readable-stream/-/readable-stream-2.3.7.tgz",
             "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
             "dev": true,
             "requires": {
@@ -5554,7 +5554,7 @@
         },
         "redent": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/redent/-/redent-3.0.0.tgz",
             "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
             "dev": true,
             "requires": {
@@ -5595,7 +5595,7 @@
         },
         "request": {
             "version": "2.88.2",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/request/-/request-2.88.2.tgz",
             "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
             "dev": true,
             "requires": {
@@ -5629,13 +5629,13 @@
         },
         "require-main-filename": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
         },
         "resolve": {
             "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/resolve/-/resolve-1.17.0.tgz",
             "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
             "dev": true,
             "requires": {
@@ -5695,7 +5695,7 @@
         },
         "rimraf": {
             "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/rimraf/-/rimraf-2.7.1.tgz",
             "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
             "dev": true,
             "requires": {
@@ -5704,7 +5704,7 @@
         },
         "run-async": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/run-async/-/run-async-2.4.1.tgz",
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
             "dev": true
         },
@@ -5719,7 +5719,7 @@
         },
         "rxjs": {
             "version": "6.6.2",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/rxjs/-/rxjs-6.6.2.tgz",
             "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
             "dev": true,
             "requires": {
@@ -5728,7 +5728,7 @@
         },
         "safe-buffer": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
         },
@@ -5749,7 +5749,7 @@
         },
         "semver": {
             "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-6.3.0.tgz",
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
             "dev": true
         },
@@ -5784,7 +5784,7 @@
         },
         "shallow-clone": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/shallow-clone/-/shallow-clone-3.0.1.tgz",
             "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
             "requires": {
@@ -5808,13 +5808,13 @@
         },
         "signal-exit": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
             "dev": true
         },
         "slash": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/slash/-/slash-2.0.0.tgz",
             "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
             "dev": true
         },
@@ -5826,7 +5826,7 @@
         },
         "smart-buffer": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/smart-buffer/-/smart-buffer-4.1.0.tgz",
             "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
             "dev": true
         },
@@ -5954,7 +5954,7 @@
         },
         "socks": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/socks/-/socks-2.3.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/socks/-/socks-2.3.3.tgz",
             "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
             "dev": true,
             "requires": {
@@ -6000,7 +6000,7 @@
         },
         "source-map-resolve": {
             "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
             "dev": true,
             "requires": {
@@ -6019,7 +6019,7 @@
         },
         "spdx-correct": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/spdx-correct/-/spdx-correct-3.1.1.tgz",
             "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
             "dev": true,
             "requires": {
@@ -6029,13 +6029,13 @@
         },
         "spdx-exceptions": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
             "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
             "dev": true
         },
         "spdx-expression-parse": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
             "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
             "dev": true,
             "requires": {
@@ -6045,7 +6045,7 @@
         },
         "spdx-license-ids": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
             "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
@@ -6141,7 +6141,7 @@
         },
         "stream-shift": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/stream-shift/-/stream-shift-1.0.1.tgz",
             "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
             "dev": true
         },
@@ -6158,7 +6158,7 @@
         },
         "string.prototype.trimend": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
             "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
             "dev": true,
             "requires": {
@@ -6168,7 +6168,7 @@
         },
         "string.prototype.trimstart": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
             "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
             "dev": true,
             "requires": {
@@ -6216,7 +6216,7 @@
         },
         "strip-indent": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-indent/-/strip-indent-3.0.0.tgz",
             "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
             "dev": true,
             "requires": {
@@ -6245,7 +6245,7 @@
         },
         "tar": {
             "version": "4.4.13",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/tar/-/tar-4.4.13.tgz",
             "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
             "dev": true,
             "requires": {
@@ -6280,7 +6280,7 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 }
@@ -6288,13 +6288,13 @@
         },
         "text-extensions": {
             "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/text-extensions/-/text-extensions-1.9.0.tgz",
             "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==",
             "dev": true
         },
         "thenify": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/thenify/-/thenify-3.3.1.tgz",
             "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
             "dev": true,
             "requires": {
@@ -6303,7 +6303,7 @@
         },
         "thenify-all": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/thenify-all/-/thenify-all-1.6.0.tgz",
             "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
             "dev": true,
             "requires": {
@@ -6379,7 +6379,7 @@
         },
         "tough-cookie": {
             "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
             "dev": true,
             "requires": {
@@ -6398,7 +6398,7 @@
         },
         "trim-newlines": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/trim-newlines/-/trim-newlines-3.0.0.tgz",
             "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
             "dev": true
         },
@@ -6410,7 +6410,7 @@
         },
         "tslib": {
             "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/tslib/-/tslib-1.13.0.tgz",
             "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
             "dev": true
         },
@@ -6431,7 +6431,7 @@
         },
         "type-fest": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/type-fest/-/type-fest-0.3.1.tgz",
             "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
             "dev": true
         },
@@ -6443,7 +6443,7 @@
         },
         "uglify-js": {
             "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/uglify-js/-/uglify-js-3.10.1.tgz",
             "integrity": "sha512-RjxApKkrPJB6kjJxQS3iZlf///REXWYxYJxO/MpmlQzVkDWVI3PSnCBWezMecmTU/TRkNxrl8bmsfFQCp+LO+Q==",
             "dev": true,
             "optional": true
@@ -6492,7 +6492,7 @@
         },
         "universal-user-agent": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/universal-user-agent/-/universal-user-agent-4.0.1.tgz",
             "integrity": "sha512-LnST3ebHwVL2aNe4mejI9IQh2HfZ1RLo8Io2HugSif8ekzD1TlWpHpColOB/eh8JHMLkGH3Akqf040I+4ylNxg==",
             "dev": true,
             "requires": {
@@ -6547,7 +6547,7 @@
         },
         "upath": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
             "dev": true
         },
@@ -6589,7 +6589,7 @@
         },
         "uuid": {
             "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/uuid/-/uuid-3.4.0.tgz",
             "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
             "dev": true
         },
@@ -6640,7 +6640,7 @@
         },
         "whatwg-url": {
             "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/whatwg-url/-/whatwg-url-7.1.0.tgz",
             "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
             "dev": true,
             "requires": {
@@ -6675,7 +6675,7 @@
         },
         "windows-release": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/windows-release/-/windows-release-3.3.3.tgz",
             "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
             "dev": true,
             "requires": {
@@ -6684,13 +6684,13 @@
         },
         "wordwrap": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/wordwrap/-/wordwrap-1.0.0.tgz",
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
         },
         "wrap-ansi": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
             "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
             "dev": true,
             "requires": {
@@ -6701,19 +6701,19 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
                 "string-width": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/string-width/-/string-width-3.1.0.tgz",
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
@@ -6724,7 +6724,7 @@
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
@@ -6752,7 +6752,7 @@
         },
         "write-json-file": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-3.2.0.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/write-json-file/-/write-json-file-3.2.0.tgz",
             "integrity": "sha512-3xZqT7Byc2uORAatYiP3DHUUAVEkNOswEWNs9H5KXiicRTvzYzYqKjYc4G7p+8pltvAw641lVByKVtMpf+4sYQ==",
             "dev": true,
             "requires": {
@@ -6766,7 +6766,7 @@
             "dependencies": {
                 "make-dir": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/make-dir/-/make-dir-2.1.0.tgz",
                     "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
                     "dev": true,
                     "requires": {
@@ -6776,7 +6776,7 @@
                 },
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "dev": true
                 }
@@ -6794,13 +6794,13 @@
             "dependencies": {
                 "pify": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/pify/-/pify-3.0.0.tgz",
                     "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
                     "dev": true
                 },
                 "write-json-file": {
                     "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-2.3.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/write-json-file/-/write-json-file-2.3.0.tgz",
                     "integrity": "sha1-K2TIozAE1UuGmMdtWFp3zrYdoy8=",
                     "dev": true,
                     "requires": {
@@ -6816,7 +6816,7 @@
         },
         "xtend": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true
         },
@@ -6828,13 +6828,13 @@
         },
         "yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "yargs": {
             "version": "14.2.3",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/yargs/-/yargs-14.2.3.tgz",
             "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
             "dev": true,
             "requires": {
@@ -6853,7 +6853,7 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/ansi-regex/-/ansi-regex-4.1.0.tgz",
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
@@ -6865,7 +6865,7 @@
                 },
                 "string-width": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/string-width/-/string-width-3.1.0.tgz",
                     "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
@@ -6876,7 +6876,7 @@
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
@@ -6887,7 +6887,7 @@
         },
         "yargs-parser": {
             "version": "15.0.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+            "resolved": "https://phx-nexus-proxy.internal.salesforce.com/nexus/content/groups/npm-all/yargs-parser/-/yargs-parser-15.0.1.tgz",
             "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
             "dev": true,
             "requires": {

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -29,7 +29,9 @@ import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.json.JsonInput
 import kotlinx.serialization.json.JsonOutput
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Calendar
+import java.util.Date
+import java.util.TimeZone
 
 @Serializable
 data class TestStruct(

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -29,9 +29,7 @@ import kotlinx.serialization.json.JsonConfiguration
 import kotlinx.serialization.json.JsonInput
 import kotlinx.serialization.json.JsonOutput
 import java.text.SimpleDateFormat
-import java.util.Calendar
-import java.util.Date
-import java.util.TimeZone
+import java.util.*
 
 @Serializable
 data class TestStruct(
@@ -398,4 +396,21 @@ class TestPlugin : Plugin, EventPublisher<StructEvent> by DefaultEventPublisher(
         callback(param0 - 1)
         return param0 - 2
     }
+
+    @BoundMethod
+    fun takesString(stringParam: String): String {
+        return stringParam
+    }
+
+    @BoundMethod
+    fun takesNumber(numberParam: Double) {}
+
+    @BoundMethod
+    fun takesBool(boolParam: Boolean) {}
+
+    @BoundMethod
+    fun takesDictionary(dictionaryParam: Map<String, String>) {}
+
+    @BoundMethod
+    fun takesTestStruct(testStructParam: TestStruct) {}
 }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -381,9 +381,128 @@ class V8PluginTests {
 
     // endregion
 
-    private fun executeTest(function: String) {
+    // region parameter errors
+
+    @Test
+    fun testVerifyStringDecoderRejectsInt() {
+        executeTest("verifyStringDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsBool() {
+        executeTest("verifyStringDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsNull() {
+        executeTest("verifyStringDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsUndefined() {
+        executeTest("verifyStringDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderResolvesStringNull() {
+        executeTest("verifyStringDecoderResolvesStringNull()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsString() {
+        executeTest("verifyNumberDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsObject() {
+        executeTest("verifyNumberDecoderRejectsObject()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsNull() {
+        executeTest("verifyNumberDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsUndefined() {
+        executeTest("verifyNumberDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsString() {
+        executeTest("verifyBoolDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsObject() {
+        executeTest("verifyBoolDecoderRejectsObject()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsNull() {
+        executeTest("verifyBoolDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsUndefined() {
+        executeTest("verifyBoolDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsString() {
+        executeTest("verifyDictionaryDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsInt() {
+        executeTest("verifyDictionaryDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsBool() {
+        executeTest("verifyDictionaryDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsNull() {
+        executeTest("verifyDictionaryDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsUndefined() {
+        executeTest("verifyDictionaryDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsString() {
+        executeTest("verifyTestStructDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsInt() {
+        executeTest("verifyTestStructDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsBool() {
+        executeTest("verifyTestStructDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsNull() {
+        executeTest("verifyTestStructDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsUndefined() {
+        executeTest("verifyTestStructDecoderRejectsUndefined()")
+    }
+
+    // endregion
+
+    private fun executeTest(funtion: String) {
         assertThat(expectPlugin.testReady.await(30, TimeUnit.SECONDS)).isTrue()
-        bridge.executorScope(executorService) { bridge.executeScriptOnExecutor(function) }
+        bridge.executorScope(executorService) { bridge.executeScriptOnExecutor(funtion) }
         assertThat(expectPlugin.testFinished.await(30, TimeUnit.SECONDS)).isTrue()
         assertThat(expectPlugin.passed).isTrue()
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/v8/V8PluginTests.kt
@@ -500,9 +500,9 @@ class V8PluginTests {
 
     // endregion
 
-    private fun executeTest(funtion: String) {
+    private fun executeTest(function: String) {
         assertThat(expectPlugin.testReady.await(30, TimeUnit.SECONDS)).isTrue()
-        bridge.executorScope(executorService) { bridge.executeScriptOnExecutor(funtion) }
+        bridge.executorScope(executorService) { bridge.executeScriptOnExecutor(function) }
         assertThat(expectPlugin.testFinished.await(30, TimeUnit.SECONDS)).isTrue()
         assertThat(expectPlugin.passed).isTrue()
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -445,81 +445,81 @@ class WebViewPluginTests {
 
     // region parameter errors
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyStringDecoderRejectsInt() {
-//        executeTest("verifyStringDecoderRejectsInt()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyStringDecoderRejectsInt() {
+        executeTest("verifyStringDecoderRejectsInt()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyStringDecoderRejectsBool() {
-//        executeTest("verifyStringDecoderRejectsBool()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyStringDecoderRejectsBool() {
+        executeTest("verifyStringDecoderRejectsBool()")
+    }
 
     @Test
     fun testVerifyStringDecoderRejectsNull() {
         executeTest("verifyStringDecoderRejectsNull()")
     }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyStringDecoderRejectsUndefined() {
-//        executeTest("verifyStringDecoderRejectsUndefined()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyStringDecoderRejectsUndefined() {
+        executeTest("verifyStringDecoderRejectsUndefined()")
+    }
 
     @Test
     fun testVerifyStringDecoderResolvesStringNull() {
         executeTest("verifyStringDecoderResolvesStringNull()")
     }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyNumberDecoderRejectsString() {
-//        executeTest("verifyNumberDecoderRejectsString()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyNumberDecoderRejectsString() {
+        executeTest("verifyNumberDecoderRejectsString()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyNumberDecoderRejectsObject() {
-//        executeTest("verifyNumberDecoderRejectsObject()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyNumberDecoderRejectsObject() {
+        executeTest("verifyNumberDecoderRejectsObject()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyNumberDecoderRejectsNull() {
-//        executeTest("verifyNumberDecoderRejectsNull()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyNumberDecoderRejectsNull() {
+        executeTest("verifyNumberDecoderRejectsNull()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyNumberDecoderRejectsUndefined() {
-//        executeTest("verifyNumberDecoderRejectsUndefined()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyNumberDecoderRejectsUndefined() {
+        executeTest("verifyNumberDecoderRejectsUndefined()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyBoolDecoderRejectsString() {
-//        executeTest("verifyBoolDecoderRejectsString()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyBoolDecoderRejectsString() {
+        executeTest("verifyBoolDecoderRejectsString()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyBoolDecoderRejectsObject() {
-//        executeTest("verifyBoolDecoderRejectsObject()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyBoolDecoderRejectsObject() {
+        executeTest("verifyBoolDecoderRejectsObject()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyBoolDecoderRejectsNull() {
-//        executeTest("verifyBoolDecoderRejectsNull()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyBoolDecoderRejectsNull() {
+        executeTest("verifyBoolDecoderRejectsNull()")
+    }
 
-    // TODO: Currently not possible on Android
-//    @Test
-//    fun testVerifyBoolDecoderRejectsUndefined() {
-//        executeTest("verifyBoolDecoderRejectsUndefined()")
-//    }
+    @Ignore("Currently not possible on Android - W-8067673")
+    @Test
+    fun testVerifyBoolDecoderRejectsUndefined() {
+        executeTest("verifyBoolDecoderRejectsUndefined()")
+    }
 
     @Test
     fun testVerifyDictionaryDecoderRejectsString() {

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -443,6 +443,125 @@ class WebViewPluginTests {
 
     // endregion
 
+    // region parameter errors
+
+    @Test
+    fun testVerifyStringDecoderRejectsInt() {
+        executeTest("verifyStringDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsBool() {
+        executeTest("verifyStringDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsNull() {
+        executeTest("verifyStringDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderRejectsUndefined() {
+        executeTest("verifyStringDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyStringDecoderResolvesStringNull() {
+        executeTest("verifyStringDecoderResolvesStringNull()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsString() {
+        executeTest("verifyNumberDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsObject() {
+        executeTest("verifyNumberDecoderRejectsObject()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsNull() {
+        executeTest("verifyNumberDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyNumberDecoderRejectsUndefined() {
+        executeTest("verifyNumberDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsString() {
+        executeTest("verifyBoolDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsObject() {
+        executeTest("verifyBoolDecoderRejectsObject()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsNull() {
+        executeTest("verifyBoolDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyBoolDecoderRejectsUndefined() {
+        executeTest("verifyBoolDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsString() {
+        executeTest("verifyDictionaryDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsInt() {
+        executeTest("verifyDictionaryDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsBool() {
+        executeTest("verifyDictionaryDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsNull() {
+        executeTest("verifyDictionaryDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyDictionaryDecoderRejectsUndefined() {
+        executeTest("verifyDictionaryDecoderRejectsUndefined()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsString() {
+        executeTest("verifyTestStructDecoderRejectsString()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsInt() {
+        executeTest("verifyTestStructDecoderRejectsInt()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsBool() {
+        executeTest("verifyTestStructDecoderRejectsBool()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsNull() {
+        executeTest("verifyTestStructDecoderRejectsNull()")
+    }
+
+    @Test
+    fun testVerifyTestStructDecoderRejectsUndefined() {
+        executeTest("verifyTestStructDecoderRejectsUndefined()")
+    }
+
+    // endregion
+
     private fun executeTest(script: String) {
         expectPlugin.testReady.withTimeoutInSeconds(30) {
             runOnUiThread { webView.evaluateJavascript(script) {} }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -445,13 +445,13 @@ class WebViewPluginTests {
 
     // region parameter errors
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyStringDecoderRejectsInt() {
 //        executeTest("verifyStringDecoderRejectsInt()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyStringDecoderRejectsBool() {
 //        executeTest("verifyStringDecoderRejectsBool()")
@@ -462,7 +462,7 @@ class WebViewPluginTests {
         executeTest("verifyStringDecoderRejectsNull()")
     }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyStringDecoderRejectsUndefined() {
 //        executeTest("verifyStringDecoderRejectsUndefined()")
@@ -473,49 +473,49 @@ class WebViewPluginTests {
         executeTest("verifyStringDecoderResolvesStringNull()")
     }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyNumberDecoderRejectsString() {
 //        executeTest("verifyNumberDecoderRejectsString()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyNumberDecoderRejectsObject() {
 //        executeTest("verifyNumberDecoderRejectsObject()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyNumberDecoderRejectsNull() {
 //        executeTest("verifyNumberDecoderRejectsNull()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyNumberDecoderRejectsUndefined() {
 //        executeTest("verifyNumberDecoderRejectsUndefined()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyBoolDecoderRejectsString() {
 //        executeTest("verifyBoolDecoderRejectsString()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyBoolDecoderRejectsObject() {
 //        executeTest("verifyBoolDecoderRejectsObject()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyBoolDecoderRejectsNull() {
 //        executeTest("verifyBoolDecoderRejectsNull()")
 //    }
 
-    //TODO: Currently not possible on Android
+    // TODO: Currently not possible on Android
 //    @Test
 //    fun testVerifyBoolDecoderRejectsUndefined() {
 //        executeTest("verifyBoolDecoderRejectsUndefined()")
@@ -576,7 +576,7 @@ class WebViewPluginTests {
     private fun executeTest(script: String) {
         expectPlugin.testReady.withTimeoutInSeconds(30) {
             runOnUiThread { webView.evaluateJavascript(script) {} }
-            assertThat(expectPlugin.testFinished.await(3, TimeUnit.SECONDS)).isTrue()
+            assertThat(expectPlugin.testFinished.await(30, TimeUnit.SECONDS)).isTrue()
             assertThat(expectPlugin.passed).isTrue()
         }
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -27,6 +27,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.Ignore
 import org.junit.runner.RunWith
 import java.util.concurrent.TimeUnit
 

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -445,70 +445,81 @@ class WebViewPluginTests {
 
     // region parameter errors
 
-    @Test
-    fun testVerifyStringDecoderRejectsInt() {
-        executeTest("verifyStringDecoderRejectsInt()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyStringDecoderRejectsInt() {
+//        executeTest("verifyStringDecoderRejectsInt()")
+//    }
 
-    @Test
-    fun testVerifyStringDecoderRejectsBool() {
-        executeTest("verifyStringDecoderRejectsBool()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyStringDecoderRejectsBool() {
+//        executeTest("verifyStringDecoderRejectsBool()")
+//    }
 
     @Test
     fun testVerifyStringDecoderRejectsNull() {
         executeTest("verifyStringDecoderRejectsNull()")
     }
 
-    @Test
-    fun testVerifyStringDecoderRejectsUndefined() {
-        executeTest("verifyStringDecoderRejectsUndefined()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyStringDecoderRejectsUndefined() {
+//        executeTest("verifyStringDecoderRejectsUndefined()")
+//    }
 
     @Test
     fun testVerifyStringDecoderResolvesStringNull() {
         executeTest("verifyStringDecoderResolvesStringNull()")
     }
 
-    @Test
-    fun testVerifyNumberDecoderRejectsString() {
-        executeTest("verifyNumberDecoderRejectsString()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyNumberDecoderRejectsString() {
+//        executeTest("verifyNumberDecoderRejectsString()")
+//    }
 
-    @Test
-    fun testVerifyNumberDecoderRejectsObject() {
-        executeTest("verifyNumberDecoderRejectsObject()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyNumberDecoderRejectsObject() {
+//        executeTest("verifyNumberDecoderRejectsObject()")
+//    }
 
-    @Test
-    fun testVerifyNumberDecoderRejectsNull() {
-        executeTest("verifyNumberDecoderRejectsNull()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyNumberDecoderRejectsNull() {
+//        executeTest("verifyNumberDecoderRejectsNull()")
+//    }
 
-    @Test
-    fun testVerifyNumberDecoderRejectsUndefined() {
-        executeTest("verifyNumberDecoderRejectsUndefined()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyNumberDecoderRejectsUndefined() {
+//        executeTest("verifyNumberDecoderRejectsUndefined()")
+//    }
 
-    @Test
-    fun testVerifyBoolDecoderRejectsString() {
-        executeTest("verifyBoolDecoderRejectsString()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyBoolDecoderRejectsString() {
+//        executeTest("verifyBoolDecoderRejectsString()")
+//    }
 
-    @Test
-    fun testVerifyBoolDecoderRejectsObject() {
-        executeTest("verifyBoolDecoderRejectsObject()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyBoolDecoderRejectsObject() {
+//        executeTest("verifyBoolDecoderRejectsObject()")
+//    }
 
-    @Test
-    fun testVerifyBoolDecoderRejectsNull() {
-        executeTest("verifyBoolDecoderRejectsNull()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyBoolDecoderRejectsNull() {
+//        executeTest("verifyBoolDecoderRejectsNull()")
+//    }
 
-    @Test
-    fun testVerifyBoolDecoderRejectsUndefined() {
-        executeTest("verifyBoolDecoderRejectsUndefined()")
-    }
+    //TODO: Currently not possible on Android
+//    @Test
+//    fun testVerifyBoolDecoderRejectsUndefined() {
+//        executeTest("verifyBoolDecoderRejectsUndefined()")
+//    }
 
     @Test
     fun testVerifyDictionaryDecoderRejectsString() {
@@ -565,7 +576,7 @@ class WebViewPluginTests {
     private fun executeTest(script: String) {
         expectPlugin.testReady.withTimeoutInSeconds(30) {
             runOnUiThread { webView.evaluateJavascript(script) {} }
-            assertThat(expectPlugin.testFinished.await(30, TimeUnit.SECONDS)).isTrue()
+            assertThat(expectPlugin.testFinished.await(3, TimeUnit.SECONDS)).isTrue()
             assertThat(expectPlugin.passed).isTrue()
         }
     }


### PR DESCRIPTION
This adds the same tests for Android that were recently added for iOS to test invoking bound functions with parameters that should cause them to be rejected.

A number of scenarios were discovered that are currently not possible to support on Android without further work. These scenarios are currently commented out and I will create a story for the backlog to come up with a solution for both Android and iOS that can be implemented in a future version.