### PR TITLE
Make JSValue encoder and decoder public.

### DIFF
--- a/platforms/apple/Sources/Nimbus/JSValueDecoder.swift
+++ b/platforms/apple/Sources/Nimbus/JSValueDecoder.swift
@@ -11,7 +11,9 @@ import JavaScriptCore
 /**
  A `Decoder` class for converting from `JSValue` to a `Decodable` type.
  */
-class JSValueDecoder {
+public class JSValueDecoder {
+    public init() {}
+
     /**
      Attempt to decode the value to an instace of the given type.
      */

--- a/platforms/apple/Sources/Nimbus/JSValueEncoder.swift
+++ b/platforms/apple/Sources/Nimbus/JSValueEncoder.swift
@@ -13,7 +13,9 @@ import JavaScriptCore
 /**
  An `Encoder` class for encoding `Encodable` types to `JSValue` instances.
  */
-class JSValueEncoder {
+public class JSValueEncoder {
+    public init() {}
+
     /**
      Attempt to encode the given object to a `JSValue`.
      */


### PR DESCRIPTION
These methods can be extremely beneficial to LMR Context that is a wrapper object containing JSCore.