### PR TITLE
Roll back to using github-release-cli at 1.3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,7 +232,7 @@ jobs:
       - run:
           name: "Install node github release CLI"
           command: |
-            sudo npm install -g github-release-cli
+            sudo npm install -g github-release-cli@1.3.1
 
       - run:
           name: "Create GitHub Release"
@@ -250,7 +250,7 @@ jobs:
       - run:
           name: "Install node github release CLI"
           command: |
-            sudo npm install -g github-release-cli
+            sudo npm install -g github-release-cli@1.3.1
 
       - run:
           name: "Create GitHub Release"


### PR DESCRIPTION
Use an older version of github-release-cli to try to fix publishing issue.