### PR TITLE
Fix circle jobs that had identical names

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -541,7 +541,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^\d+\.\d+\.\d+$/
-      - push-to-cocoapods-trunk:
+      - push-to-cocoapods-trunk-pre-release:
           requires:
             - create-tagged-pre-release
           filters:


### PR DESCRIPTION
I think having these two tasks named the same was causing only the last one in the file to get parsed and therefore only working on pre-releases. This should fix that.