### PR TITLE
reverting package name with bintray fix

### DIFF
--- a/platforms/android/gradle.properties
+++ b/platforms/android/gradle.properties
@@ -25,4 +25,4 @@ POM_GITHUB_REPO=salesforce/nimbus
 
 BINTRAY_ORG=salesforce-mobile
 BINTRAY_REPO=android
-PACKAGE_NAME=com.salesforce.nimbus
+PACKAGE_NAME=nimbus


### PR DESCRIPTION
Bintray has updated the original bintray package (https://bintray.com/salesforce-mobile/android/nimbus) to publish to jcenter, so this change to package name is not longer necessary.  Future publications to the package 'nimbus' should also publish to jcenter.