### PR TITLE
Add support for Uint8Array values from web view

### DIFF
--- a/packages/@nimbus-js/runtime/src/nimbus.js
+++ b/packages/@nimbus-js/runtime/src/nimbus.js
@@ -68,7 +68,16 @@ var __nimbus = (function() {
       } else if (args[i] === null) {
         clonedArgs.push(null);
       } else if (typeof args[i] === "object") {
-        clonedArgs.push(JSON.stringify(args[i]));
+        // Uint8Arrays will be passed across as base64 strings
+        // Nimbus does not yet support other typed arrays
+        if (args[i] instanceof Uint8Array) {
+          // NOTE: this may not be the most efficient way, but it is sufficient for now
+          const str = String.fromCharCode.apply(null, args[i]);
+          const base64str = btoa(str);
+          clonedArgs.push(base64str);
+        } else {
+          clonedArgs.push(JSON.stringify(args[i]));
+        }
       } else {
         clonedArgs.push(args[i]);
       }

--- a/packages/test-www/test/shared-tests.js
+++ b/packages/test-www/test/shared-tests.js
@@ -193,6 +193,16 @@ function verifyUnaryDoubleResolvingToDouble() {
   });
 }
 
+function verifyUnaryUint8ArrayResolvingToString() {
+  let bytes = new Uint8Array([104, 101, 108, 108, 111, 44, 32, 110, 105, 109, 98, 117, 115, 33]);
+  __nimbus.plugins.testPlugin.unaryUint8ArrayResolvingToString(bytes).then((result) => {
+    if (result === 'aGVsbG8sIG5pbWJ1cyE=') {
+      __nimbus.plugins.expectPlugin.pass();
+    }
+    __nimbus.plugins.expectPlugin.finished();
+  });
+}
+
 function verifyUnaryStringResolvingToInt() {
   __nimbus.plugins.testPlugin.unaryStringResolvingToInt('some string').then((result) => {
     if (result === 11) {

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/plugin/TestPlugin.kt
@@ -201,6 +201,11 @@ class TestPlugin : Plugin, EventPublisher<StructEvent> by DefaultEventPublisher(
     }
 
     @BoundMethod
+    fun unaryUint8ArrayResolvingToString(param: String): String {
+        return param
+    }
+
+    @BoundMethod
     fun unaryStringResolvingToInt(param: String): Int {
         return param.length
     }

--- a/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
+++ b/platforms/android/shared-tests/src/androidTest/java/com/salesforce/nimbus/bridge/tests/webview/WebViewPluginTests.kt
@@ -213,6 +213,11 @@ class WebViewPluginTests {
     }
 
     @Test
+    fun verifyUnaryUint8ArrayResolvingToString() {
+        executeTest("verifyUnaryUint8ArrayResolvingToString()")
+    }
+
+    @Test
     fun verifyUnaryStringResolvingToInt() {
         executeTest("verifyUnaryStringResolvingToInt()")
     }

--- a/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsPlugin.swift
@@ -38,6 +38,7 @@ class TestPlugin: Plugin {
         connection.bind(unaryIntResolvingToInt, as: "unaryIntResolvingToInt")
         connection.bind(unaryDoubleResolvingToDouble, as: "unaryDoubleResolvingToDouble")
         connection.bind(unaryStringResolvingToInt, as: "unaryStringResolvingToInt")
+        connection.bind(unaryUint8ArrayResolvingToString, as: "unaryUint8ArrayResolvingToString")
         connection.bind(unaryStructResolvingToJsonString, as: "unaryStructResolvingToJsonString")
         connection.bind(unaryStringListResolvingToString, as: "unaryStringListResolvingToString")
         connection.bind(unaryIntListResolvingToString, as: "unaryIntListResolvingToString")
@@ -150,6 +151,10 @@ class TestPlugin: Plugin {
 
     func unaryStringResolvingToInt(param: String) -> Int {
         return param.count
+    }
+
+    func unaryUint8ArrayResolvingToString(param: String) -> String {
+        return param
     }
 
     func unaryStructResolvingToJsonString(param: TestStruct) -> String {

--- a/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
+++ b/platforms/apple/Sources/NimbusTests/SharedTestsWebView.swift
@@ -128,6 +128,10 @@ class SharedTestsWebView: XCTestCase {
         executeTest("verifyUnaryDoubleResolvingToDouble()")
     }
 
+    func testVerifyUnaryUint8ArrayResolvingToString() {
+        executeTest("verifyUnaryUint8ArrayResolvingToString()")
+    }
+
     func testVerifyUnaryStringResolvingToInt() {
         executeTest("verifyUnaryStringResolvingToInt()")
     }


### PR DESCRIPTION
With this change, Uint8Array values will be transformed into
base64-encoded strings as they cross to native. This should be better
than letting them fall to `JSON.stringify` which turns them into a
`map<string, int>`.

Support for headless environments is not yet implemented.